### PR TITLE
walkingkooka 2f83b92f7b9cff43f6b5359dd7fbfc6202ade410 20190809

### DIFF
--- a/src/main/java/walkingkooka/net/header/HeaderValueTesting.java
+++ b/src/main/java/walkingkooka/net/header/HeaderValueTesting.java
@@ -62,12 +62,12 @@ public interface HeaderValueTesting<V extends HeaderValue> extends HashCodeEqual
     V createHeaderValue();
 
     //@Override
-    default RuntimeException parseFailedExpected(final RuntimeException expected) {
+    default RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return new HeaderValueException(expected.getMessage(), expected);
     }
 
     //@Override
-    default Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    default Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return HeaderValueException.class;
     }
 

--- a/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
+++ b/src/test/java/walkingkooka/net/AbsoluteUrlTest.java
@@ -416,7 +416,7 @@ public final class AbsoluteUrlTest extends AbsoluteOrRelativeUrlTestCase<Absolut
 
     @Test
     public void testParseMissingSchemeFails() {
-        this.parseFails("example.com", IllegalArgumentException.class);
+        this.parseStringFails("example.com", IllegalArgumentException.class);
     }
 
     @Test
@@ -481,7 +481,7 @@ public final class AbsoluteUrlTest extends AbsoluteOrRelativeUrlTestCase<Absolut
 
     @Test
     public void testParseCredentialsMissingPasswordFails() {
-        this.parseFails("\"http://abc@example.com", IllegalArgumentException.class);
+        this.parseStringFails("\"http://abc@example.com", IllegalArgumentException.class);
     }
 
     @Test
@@ -694,7 +694,7 @@ public final class AbsoluteUrlTest extends AbsoluteOrRelativeUrlTestCase<Absolut
     // ParseStringTesting ..............................................................................................
 
     @Override
-    public AbsoluteUrl parse(final String text) {
+    public AbsoluteUrl parseString(final String text) {
         return AbsoluteUrl.parseAbsolute0(text);
     }
 

--- a/src/test/java/walkingkooka/net/DataUrlTest.java
+++ b/src/test/java/walkingkooka/net/DataUrlTest.java
@@ -58,32 +58,32 @@ public final class DataUrlTest extends UrlTestCase<DataUrl> {
 
     @Test
     public void testParseNonDataUrlFails() {
-        this.parseFails("http://example.com", IllegalArgumentException.class);
+        this.parseStringFails("http://example.com", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseNonBase64Fails() {
-        this.parseFails("data:text/plain;unsupported,XYZ123", IllegalArgumentException.class);
+        this.parseStringFails("data:text/plain;unsupported,XYZ123", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseMissingBinaryFails() {
-        this.parseFails("data:text/plain;base64", IllegalArgumentException.class);
+        this.parseStringFails("data:text/plain;base64", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseWithContentTypeBase64AndEncoded() {
-        this.parseAndCheck("data:text/plain;base64,YWJjMTIz", this.createUrl());
+        this.parseStringAndCheck("data:text/plain;base64,YWJjMTIz", this.createUrl());
     }
 
     @Test
     public void testParseWithContentTypeAndEncoded() {
-        this.parseAndCheck("data:text/plain,YWJjMTIz", this.createUrl());
+        this.parseStringAndCheck("data:text/plain,YWJjMTIz", this.createUrl());
     }
 
     @Test
     public void testParseWithoutContentType() {
-        this.parseAndCheck("data:;base64,YWJjMTIz", DataUrl.with(Optional.empty(), this.binary()));
+        this.parseStringAndCheck("data:;base64,YWJjMTIz", DataUrl.with(Optional.empty(), this.binary()));
     }
 
     // UrlVisitor......................................................................................................
@@ -146,7 +146,7 @@ public final class DataUrlTest extends UrlTestCase<DataUrl> {
     // ParseStringTesting...............................................................................................
 
     @Override
-    public DataUrl parse(final String text) {
+    public DataUrl parseString(final String text) {
         return DataUrl.parseData0(text);
     }
 

--- a/src/test/java/walkingkooka/net/HostAddressTest.java
+++ b/src/test/java/walkingkooka/net/HostAddressTest.java
@@ -297,119 +297,119 @@ public final class HostAddressTest implements ClassTesting2<HostAddress>,
 
     @Test
     public void testParseProbablyIp6Fails() {
-        this.parseFails("a.b:c", HostAddressProbablyIp6Problem.INSTANCE);
+        this.parseStringFails("a.b:c", HostAddressProbablyIp6Problem.INSTANCE);
     }
 
     @Test
     public void testParseDotAtStartFails() {
-        this.parseFails(".n", HostAddressInvalidCharacterProblem.with(0));
+        this.parseStringFails(".n", HostAddressInvalidCharacterProblem.with(0));
     }
 
     @Test
     public void testParseDotAtEndFails() {
-        this.parseFails("n.", HostAddressIncompleteProblem.INSTANCE);
+        this.parseStringFails("n.", HostAddressIncompleteProblem.INSTANCE);
     }
 
     @Test
     public void testParseDashAtStartFails() {
-        this.parseFails("-n", HostAddressInvalidCharacterProblem.with(0));
+        this.parseStringFails("-n", HostAddressInvalidCharacterProblem.with(0));
     }
 
     @Test
     public void testParseDashAtEndFails() {
         final String name = "n-";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
     }
 
     @Test
     public void testParseOneLabelInvalidAtStartFails() {
-        this.parseFails("!b", HostAddressInvalidCharacterProblem.with(0));
+        this.parseStringFails("!b", HostAddressInvalidCharacterProblem.with(0));
     }
 
     @Test
     public void testParseOneLabelInvalidAtStarts2Fails() {
-        this.parseFails("!bc", HostAddressInvalidCharacterProblem.with(0));
+        this.parseStringFails("!bc", HostAddressInvalidCharacterProblem.with(0));
     }
 
     @Test
     public void testParseOneLabelInvalidFails() {
-        this.parseFails("n!ame", HostAddressInvalidCharacterProblem.with(1));
+        this.parseStringFails("n!ame", HostAddressInvalidCharacterProblem.with(1));
     }
 
     @Test
     public void testParseOneLabelEndsWithInvalidFails() {
-        this.parseFails("a!", HostAddressInvalidCharacterProblem.with(1));
+        this.parseStringFails("a!", HostAddressInvalidCharacterProblem.with(1));
     }
 
     @Test
     public void testParseOneLabelEndsWithInvalid2Fails() {
-        this.parseFails("ab!", HostAddressInvalidCharacterProblem.with(2));
+        this.parseStringFails("ab!", HostAddressInvalidCharacterProblem.with(2));
     }
 
     @Test
     public void testParseDashThenDotFails() {
         final String address = "exampl-.com";
-        this.parseFails(address, HostAddressInvalidCharacterProblem.with(address.indexOf('-')));
+        this.parseStringFails(address, HostAddressInvalidCharacterProblem.with(address.indexOf('-')));
     }
 
     @Test
     public void testParseSecondLabelInvalidAtStartFails() {
         final String name = "a.!b";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
     }
 
     @Test
     public void testParseSecondLabelInvalidFails() {
         final String name = "a.b!c.d";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
     }
 
     @Test
     public void testParseSecondLabelEndsWithInvalidFails() {
         final String name = "a.b!.c";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
     }
 
     @Test
     public void testParseSecondLabelEndsWithDashFails() {
         final String name = "a.b-.c";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
     }
 
     @Test
     public void testParseLastLabelEndWithInvalidFails() {
         final String name = "a.b!";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('!')));
     }
 
     @Test
     public void testParseLastLabelEndsWithDashFails() {
         final String name = "a.b-";
-        this.parseFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
+        this.parseStringFails(name, HostAddressInvalidCharacterProblem.with(name.indexOf('-')));
     }
 
     @Test
     public void testParseIp4PartialFails() {
         final String name = "1.2";
-        this.parseFails(name, HostAddressProbablyIp4Problem.INSTANCE);
+        this.parseStringFails(name, HostAddressProbablyIp4Problem.INSTANCE);
     }
 
     @Test
     public void testParseIp4Fails() {
         final String name = "1.2.3.4";
-        this.parseFails(name, HostAddressProbablyIp4Problem.INSTANCE);
+        this.parseStringFails(name, HostAddressProbablyIp4Problem.INSTANCE);
     }
 
     @Test
     public void testParseIp4WithExtraOctetsFails() {
         final String name = "1.2.3.4.5.6";
-        this.parseFails(name, HostAddressProbablyIp4Problem.INSTANCE);
+        this.parseStringFails(name, HostAddressProbablyIp4Problem.INSTANCE);
     }
 
     @Test
     public void testParseIp6Fails() {
         final String name = "1:2:3:4:5:6:7:8";
-        this.parseFails(name, HostAddressProbablyIp6Problem.INSTANCE);
+        this.parseStringFails(name, HostAddressProbablyIp6Problem.INSTANCE);
     }
 
     @Test
@@ -417,7 +417,7 @@ public final class HostAddressTest implements ClassTesting2<HostAddress>,
         final char[] array = new char[HostAddress.MAX_LABEL_LENGTH];
         Arrays.fill(array, 'x');
         final String name = new String(array);
-        this.parseFails(name, HostAddressInvalidLengthProblem.with(0));
+        this.parseStringFails(name, HostAddressInvalidLengthProblem.with(0));
     }
 
     @Test
@@ -425,77 +425,77 @@ public final class HostAddressTest implements ClassTesting2<HostAddress>,
         final char[] array = new char[HostAddress.MAX_LABEL_LENGTH];
         Arrays.fill(array, 'x');
         final String name = new String(array);
-        this.parseFails(name + ".second", HostAddressInvalidLengthProblem.with(0));
+        this.parseStringFails(name + ".second", HostAddressInvalidLengthProblem.with(0));
     }
 
     public void testParseLabelTooLongSecondFails() {
         final char[] array = new char[HostAddress.MAX_LABEL_LENGTH];
         Arrays.fill(array, 'x');
-        this.parseFails("first." + new String(array) + ".last", HostAddressInvalidLengthProblem.with("first.".length()));
+        this.parseStringFails("first." + new String(array) + ".last", HostAddressInvalidLengthProblem.with("first.".length()));
     }
 
     @Test
     public void testParseLabelTooLongLastFails() {
         final char[] array = new char[HostAddress.MAX_LABEL_LENGTH];
         Arrays.fill(array, 'x');
-        this.parseFails("first." + new String(array), HostAddressInvalidLengthProblem.with("first.".length()));
+        this.parseStringFails("first." + new String(array), HostAddressInvalidLengthProblem.with("first.".length()));
     }
 
     @Test
     public void testParseOneLetter() {
-        this.parseAndCheck("A");
+        this.parseStringAndCheck("A");
     }
 
     @Test
     public void testParseOneLetterWithStartAndEnd() {
-        this.parseAndCheck("!B!", 1, 2);
+        this.parseStringAndCheck("!B!", 1, 2);
     }
 
     @Test
     public void testParseOneLabel() {
-        this.parseAndCheck("one");
+        this.parseStringAndCheck("one");
     }
 
     @Test
     public void testParseOneLabelWithStartAndEnd() {
-        this.parseAndCheck("!one!", 1, 4);
+        this.parseStringAndCheck("!one!", 1, 4);
     }
 
     @Test
     public void testParseManyLabels() {
-        this.parseAndCheck("first.second");
+        this.parseStringAndCheck("first.second");
     }
 
     @Test
     public void testParseManyLabelsWithStartAndEnd() {
         final String address = "!first.second!";
-        this.parseAndCheck(address, 1, address.length() - 1);
+        this.parseStringAndCheck(address, 1, address.length() - 1);
     }
 
     @Test
     public void testParseManyLabels2() {
-        this.parseAndCheck("first.second.third");
+        this.parseStringAndCheck("first.second.third");
     }
 
     @Test
     public void testParseManyLabels2WithStartAndEnd() {
         final String address = "!first.second.third!";
-        this.parseAndCheck(address, 1, address.length() - 1);
+        this.parseStringAndCheck(address, 1, address.length() - 1);
     }
 
-    private void parseAndCheck(final String address) {
-        this.parseAndCheck(address, 0, address.length());
+    private void parseStringAndCheck(final String address) {
+        this.parseStringAndCheck(address, 0, address.length());
     }
 
-    private void parseAndCheck(final String address, final int start, final int end) {
+    private void parseStringAndCheck(final String address, final int start, final int end) {
         assertNull(HostAddress.tryParseName(address, start, end));
     }
 
-    private void parseFails(final String address, final HostAddressProblem problem) {
-        this.parseFails(address, 0, address.length(), problem);
+    private void parseStringFails(final String address, final HostAddressProblem problem) {
+        this.parseStringFails(address, 0, address.length(), problem);
     }
 
-    private void parseFails(final String address, final int start, final int end, final HostAddressProblem problem) {
+    private void parseStringFails(final String address, final int start, final int end, final HostAddressProblem problem) {
         assertEquals(problem, HostAddress.tryParseName(address, start, end), "problem");
     }
 

--- a/src/test/java/walkingkooka/net/RelativeUrlTest.java
+++ b/src/test/java/walkingkooka/net/RelativeUrlTest.java
@@ -29,16 +29,8 @@ public final class RelativeUrlTest extends AbsoluteOrRelativeUrlTestCase<Relativ
 
     // parseRelative..........................................................................................
 
-    @Test
-    public void testParseNullFails() {
-        assertThrows(NullPointerException.class, () -> {
-            RelativeUrl.parseRelative0(null);
-        });
-    }
-
     @Override
-    public void testParseEmptyFails() {
-        throw new UnsupportedOperationException();
+    public void testParseStringEmptyFails() {
     }
 
     @Test
@@ -163,7 +155,7 @@ public final class RelativeUrlTest extends AbsoluteOrRelativeUrlTestCase<Relativ
     // ParseStringTesting ..............................................................................................
 
     @Override
-    public RelativeUrl parse(final String text) {
+    public RelativeUrl parseString(final String text) {
         return RelativeUrl.parseRelative0(text);
     }
 

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -38,18 +38,18 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
         SerializationTesting<UrlPath> {
 
     @Test
-    public void testParseEmpty() {
-        this.parseAndCheck("", UrlPath.EMPTY);
+    public void testParseStringEmpty() {
+        this.parseStringAndCheck("", UrlPath.EMPTY);
     }
 
     @Override
-    public void testParseEmptyFails() {
+    public void testParseStringEmptyFails() {
         // ignored
     }
 
     @Test
     public void testParseRoot() {
-        assertSame(UrlPath.ROOT, this.parseAndCheck("/", UrlPath.ROOT));
+        assertSame(UrlPath.ROOT, this.parseStringAndCheck("/", UrlPath.ROOT));
     }
 
     @Test
@@ -204,17 +204,17 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     // ParseStringTesting ........................................................................................
 
     @Override
-    public UrlPath parse(final String text) {
+    public UrlPath parseString(final String text) {
         return UrlPath.parse(text);
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/net/UrlTest.java
+++ b/src/test/java/walkingkooka/net/UrlTest.java
@@ -31,7 +31,7 @@ public final class UrlTest implements ClassTesting2<Url>,
         ParseStringTesting<Url> {
 
     @Override
-    public void testParseEmptyFails() {
+    public void testParseStringEmptyFails() {
         throw new UnsupportedOperationException();
     }
 
@@ -39,28 +39,28 @@ public final class UrlTest implements ClassTesting2<Url>,
     public void testParseAbsoluteUrl() {
         final String text = "http://example.com";
 
-        this.parseAndCheck(text, Url.parseAbsolute(text));
+        this.parseStringAndCheck(text, Url.parseAbsolute(text));
     }
 
     @Test
     public void testParseDataUrl() {
         final DataUrl url = Url.data(Optional.of(MediaType.TEXT_PLAIN), Binary.with("abc123".getBytes(Charset.defaultCharset())));
 
-        this.parseAndCheck(url.value(), Url.parseData(url.value()));
+        this.parseStringAndCheck(url.value(), Url.parseData(url.value()));
     }
 
     @Test
     public void testParseRelativeUrl() {
         final String text = "/path123?query456";
 
-        this.parseAndCheck(text, Url.parseRelative(text));
+        this.parseStringAndCheck(text, Url.parseRelative(text));
     }
 
     @Test
     public void testParseRelativeUrlEmpty() {
         final String text = "";
 
-        this.parseAndCheck(text, Url.parseRelative(text));
+        this.parseStringAndCheck(text, Url.parseRelative(text));
     }
 
     @Override
@@ -76,17 +76,17 @@ public final class UrlTest implements ClassTesting2<Url>,
     // ParseStringTesting ........................................................................................
 
     @Override
-    public Url parse(final String text) {
+    public Url parseString(final String text) {
         return Url.parse(text);
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/net/UrlTestCase.java
+++ b/src/test/java/walkingkooka/net/UrlTestCase.java
@@ -95,12 +95,12 @@ abstract public class UrlTestCase<U extends Url> implements ClassTesting2<U>,
     // ParseStringTesting ..............................................................................................
 
     @Override
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 
     @Override
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/net/email/DominicsayersComIsemailEmailAddressTestGenerator.java
+++ b/src/test/java/walkingkooka/net/email/DominicsayersComIsemailEmailAddressTestGenerator.java
@@ -91,7 +91,7 @@ final public class DominicsayersComIsemailEmailAddressTestGenerator {
         // print tests one by one
         for (final Entry<String, TestDetails> idAndTest : tests.entrySet()) {
             final TestDetails test = idAndTest.getValue();
-            final String valid = test.valid ? "parseSuccessful" : "parseFails2";
+            final String valid = test.valid ? "parseSuccessful" : "parseStringFails2";
             final String comment = test.comment;
             final String email = test.email;
 

--- a/src/test/java/walkingkooka/net/email/EmailAddressParserTestCase.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressParserTestCase.java
@@ -32,42 +32,42 @@ public abstract class EmailAddressParserTestCase<P extends EmailAddressParser> i
 
     @Test
     public final void testValid() {
-        this.parse("user@example.com");
+        this.parseString("user@example.com");
     }
 
-    abstract void parse(final String text);
+    abstract void parseString(final String text);
 
     @Test
     public final void testEmailTooLongFails() {
-        this.parseFails("user1234567890@example" + CharSequences.repeating('0', 255));
+        this.parseStringFails("user1234567890@example" + CharSequences.repeating('0', 255));
     }
 
     @Test
     public final void testMissingUserFails() {
-        this.parseFails("@example.com");
+        this.parseStringFails("@example.com");
     }
 
     @Test
     public final void testUserNameTooLongFails() {
-        this.parseFails("user" + CharSequences.repeating('0', 100) + "@example.com");
+        this.parseStringFails("user" + CharSequences.repeating('0', 100) + "@example.com");
     }
 
     @Test
     public final void testMissingHostFails() {
-        this.parseFails("user@");
+        this.parseStringFails("user@");
     }
 
     @Test
     public final void testMissingHostFails2() {
-        this.parseFails("user");
+        this.parseStringFails("user");
     }
 
     @Test
     public final void testInvalidCharacterFails() {
-        this.parseFails("user@:example.com");
+        this.parseStringFails("user@:example.com");
     }
 
-    abstract void parseFails(final String text);
+    abstract void parseStringFails(final String text);
 
     // ClassTesting.....................................................................................................
 

--- a/src/test/java/walkingkooka/net/email/EmailAddressParserTryParseTest.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressParserTryParseTest.java
@@ -32,12 +32,12 @@ public final class EmailAddressParserTryParseTest extends EmailAddressParserTest
     }
 
     @Override
-    void parse(final String text) {
+    void parseString(final String text) {
         EmailAddressParserTryParse.tryParse(text);
     }
 
     @Override
-    void parseFails(final String text) {
+    void parseStringFails(final String text) {
         assertEquals(Optional.empty(),
                 EmailAddressParserTryParse.tryParse(text),
                 () -> "parse " + CharSequences.quoteAndEscape(text));

--- a/src/test/java/walkingkooka/net/email/EmailAddressParserWithTest.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressParserWithTest.java
@@ -29,12 +29,12 @@ public final class EmailAddressParserWithTest extends EmailAddressParserTestCase
     }
 
     @Override
-    void parse(final String text) {
+    void parseString(final String text) {
         EmailAddressParserWith.parseOrFail(text);
     }
 
     @Override
-    void parseFails(final String text) {
+    void parseStringFails(final String text) {
         assertThrows(RuntimeException.class, () -> {
             EmailAddressParserWith.parseOrFail(text);
         });

--- a/src/test/java/walkingkooka/net/email/EmailAddressTest.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressTest.java
@@ -61,21 +61,21 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     @Test
     public void testOnlyWhitespaceFails() {
         final String email = "    ";
-        this.parseFails2(email, new InvalidCharacterException(email, 0));
+        this.parseStringFails2(email, new InvalidCharacterException(email, 0));
     }
 
     @Test
     public void testTooLongFails() {
         final char[] array = new char[EmailAddress.MAX_EMAIL_LENGTH - 5];
         Arrays.fill(array, 'x');
-        this.parseFails2("user@" + new String(array),
+        this.parseStringFails2("user@" + new String(array),
                 InvalidTextLengthException.class,
                 null);
     }
 
     @Test
     public void testTooShortFails() {
-        this.parseFails2(".", new InvalidCharacterException(".", 0));
+        this.parseStringFails2(".", new InvalidCharacterException(".", 0));
     }
 
     @Test
@@ -112,67 +112,67 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     private void invalidUserNameCharacter(final String email, final char c) {
         final int at = email.indexOf(c);
         assertNotEquals(-1, at, "invalid character '" + c + "' does not appear in email=" + email);
-        this.parseFails2(email, new InvalidCharacterException(email, at));
+        this.parseStringFails2(email, new InvalidCharacterException(email, at));
     }
 
     @Test
     public void testServerContainsInvalidCharacterFails() {
         final String email = "user@s erver";
-        this.parseFails2(email, new InvalidCharacterException(email, email.lastIndexOf(' ')));
+        this.parseStringFails2(email, new InvalidCharacterException(email, email.lastIndexOf(' ')));
     }
 
     @Test
     public void testExtraAtSignFails() {
         final String email = "user@extra@atsign";
-        this.parseFails2(email, new InvalidCharacterException(email, email.lastIndexOf('@')));
+        this.parseStringFails2(email, new InvalidCharacterException(email, email.lastIndexOf('@')));
     }
 
     @Test
     public void testWithoutUserFails() {
         final String email = "@server";
-        this.parseFails2(email, EmailAddress.missingUser(email));
+        this.parseStringFails2(email, EmailAddress.missingUser(email));
     }
 
     @Test
     public void testWithoutHostFails() {
         final String email = "user@";
-        this.parseFails2(email, EmailAddress.missingHost(email));
+        this.parseStringFails2(email, EmailAddress.missingHost(email));
     }
 
     @Test
     public void testDoubleDotFails() {
         final String email = "use..r@serve";
-        this.parseFails2(email, new InvalidCharacterException(email, email.indexOf("..") + 1));
+        this.parseStringFails2(email, new InvalidCharacterException(email, email.indexOf("..") + 1));
     }
 
     @Test
     public void testIp4MissingClosingBracketFails() {
         final String email = "user@[1.2.3.4";
-        this.parseFails2(email, HostAddressProblem.incomplete());
+        this.parseStringFails2(email, HostAddressProblem.incomplete());
     }
 
     @Test
     public void testIp6MissingClosingBracketFails() {
         final String email = "user@[1:2:3:4:5:6:7:8";
-        this.parseFails2(email, HostAddressProblem.incomplete());
+        this.parseStringFails2(email, HostAddressProblem.incomplete());
     }
 
     @Test
     public void testIp4UnnecesssaryClosingBracketFails() {
         final String email = "user@1.2.3.4]";
-        this.parseFails2(email, new InvalidCharacterException(email, email.lastIndexOf(']')));
+        this.parseStringFails2(email, new InvalidCharacterException(email, email.lastIndexOf(']')));
     }
 
     @Test
     public void testIp6EmbeddedIp4WithInvalidValueFails() {
         final String email = "user@1:2:3:4:5:6:7.888.9.0";
-        this.parseFails2(email, HostAddressProblem.invalidValue(email.indexOf('8')));
+        this.parseStringFails2(email, HostAddressProblem.invalidValue(email.indexOf('8')));
     }
 
     @Test
     public void testIp6UnnecessaryClosingBracketFails() {
         final String email = "user@1:2:3:4:5:6:7:8]";
-        this.parseFails2(email, new InvalidCharacterException(email, email.lastIndexOf(']')));
+        this.parseStringFails2(email, new InvalidCharacterException(email, email.lastIndexOf(']')));
     }
 
     @Test
@@ -180,31 +180,31 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
         final char[] user = new char[EmailAddress.MAX_LOCAL_LENGTH];
         Arrays.fill(user, 'a');
 
-        this.parseFails2(new String(user) + "@example.com",
+        this.parseStringFails2(new String(user) + "@example.com",
                 InvalidTextLengthException.class,
                 null);
     }
 
-    private void parseFails2(final String address, final HostAddressProblem problem) {
-        this.parseFails2(address,
+    private void parseStringFails2(final String address, final HostAddressProblem problem) {
+        this.parseStringFails2(address,
                 problem.message(address));
     }
 
-    private void parseFails2(final String email, final RuntimeException thrown) {
-        parseFails2(email,
+    private void parseStringFails2(final String email, final RuntimeException thrown) {
+        parseStringFails2(email,
                 thrown.getClass(),
                 thrown.getMessage());
         assertEquals(Optional.empty(), EmailAddress.tryParse(email), email);
     }
 
-    private void parseFails2(final String email, final String expectedMessage) {
-        parseFails2(email,
+    private void parseStringFails2(final String email, final String expectedMessage) {
+        parseStringFails2(email,
                 IllegalArgumentException.class,
                 expectedMessage);
         assertEquals(Optional.empty(), EmailAddress.tryParse(email), email);
     }
 
-    private <T extends RuntimeException> void parseFails2(final String email,
+    private <T extends RuntimeException> void parseStringFails2(final String email,
                                                           final Class<T> thrown,
                                                           final String message) {
         final T expected = assertThrows(thrown, () -> {
@@ -219,75 +219,75 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void testWith() {
-        this.parseAndCheck("user", "server");
+        this.parseStringAndCheck("user", "server");
     }
 
     @Test
     public void testWith2() {
-        this.parseAndCheck("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!.#$%&'*+-/=?^_`{|}~", "server");
+        this.parseStringAndCheck("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!.#$%&'*+-/=?^_`{|}~", "server");
     }
 
     @Test
     public void testUsernameWithQuotedSquareBrackets() {
-        this.parseAndCheck("user\"[]\"", "server");
+        this.parseStringAndCheck("user\"[]\"", "server");
     }
 
     @Test
     public void testUsernameWithQuotedLessAndGreaterThan() {
-        this.parseAndCheck("user\"<>\"", "server");
+        this.parseStringAndCheck("user\"<>\"", "server");
     }
 
     @Test
     public void testUsernameWithQuotedColon() {
-        this.parseAndCheck("user\":\"", "server");
+        this.parseStringAndCheck("user\":\"", "server");
     }
 
     @Test
     public void testUsernameWithQuotedSemiColon() {
-        this.parseAndCheck("user\":\"", "server");
+        this.parseStringAndCheck("user\":\"", "server");
     }
 
     @Test
     public void testUsernameWithQuotedAtSign() {
-        this.parseAndCheck("user\"@\"", "server");
+        this.parseStringAndCheck("user\"@\"", "server");
     }
 
     @Test
     public void testUsernameWithQuotedBackslash() {
-        this.parseAndCheck("user\"\\\\\"", "server");
+        this.parseStringAndCheck("user\"\\\\\"", "server");
     }
 
     @Test
     public void testIp4Address() {
-        this.parseAndCheck("user", "1.2.3.4");
+        this.parseStringAndCheck("user", "1.2.3.4");
     }
 
     @Test
     public void testIp4AddressSurroundedBySquareBrackets() {
-        this.parseAndCheck("user", "[1.2.3.4]");
+        this.parseStringAndCheck("user", "[1.2.3.4]");
     }
 
     @Test
     public void testIp6Address() {
-        this.parseAndCheck("user", "1111:2222:3333:4444:5555:6666:7777:8888");
+        this.parseStringAndCheck("user", "1111:2222:3333:4444:5555:6666:7777:8888");
     }
 
     @Test
     public void testIp6AddressWithEmbeddedIp4() {
-        this.parseAndCheck("user", "1111:2222:3333:4444:5555:6666:255.7.8.9");
+        this.parseStringAndCheck("user", "1111:2222:3333:4444:5555:6666:255.7.8.9");
     }
 
     @Test
     public void testIp6AddressSurroundedBySquareBrackets() {
-        this.parseAndCheck("user", "[1111:2222:3333:4444:5555:6666:7777:8888]");
+        this.parseStringAndCheck("user", "[1111:2222:3333:4444:5555:6666:7777:8888]");
     }
 
     @Test
     public void testManyNoneConsecutiveDots() {
-        this.parseAndCheck("first.middle.last", "server");
+        this.parseStringAndCheck("first.middle.last", "server");
     }
 
-    private void parseAndCheck(final String user, final String server) {
+    private void parseStringAndCheck(final String user, final String server) {
         final String address = user + '@' + server;
         final EmailAddress emailAddress = EmailAddress.parse(address);
         this.parseSuccessful(user, server, emailAddress);
@@ -317,7 +317,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test003__first_DOT_last_ATSIGN_sub_DOT_docom__Mistyped_comma_instead_of_dot__LEFT_PAREN_replaces_old_3_which_was_the_same_as_57_RIGHT_PAREN_() {
-        this.parseFailsWithComment("first.last@sub.do,com",
+        this.parseStringFailsWithComment("first.last@sub.do,com",
                 "Mistyped comma instead of dot (replaces old #3 which was the same as #57)");
     }
 
@@ -328,7 +328,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test005__first_ATSIGN_last_ATSIGN_iana_DOT_org__Escaping_can_only_happen_within_a_quoted_string() {
-        this.parseFailsWithComment("first\\@last@iana.org", "Escaping can only happen within a quoted string");
+        this.parseStringFailsWithComment("first\\@last@iana.org", "Escaping can only happen within a quoted string");
     }
 
     @Test
@@ -412,40 +412,40 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test021__123456789012345678901234567890123456789012345678901234567890_ATSIGN_12345678901234567890123456789012345678901234567890123456789_DOT_12345678901234567890123456789012345678901234567890123456789_DOT_12345678901234567890123456789012345678901234567890123456789_DOT_12345_DOT_iana_DOT_org__Entire_address_is_longer_than_254_characters() {
-        this.parseFailsWithComment(
+        this.parseStringFailsWithComment(
                 "123456789012345678901234567890123456789012345678901234567890@12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345678901234567890123456789012345678901234567890123456789.12345.iana.org",
                 "Entire address is longer than 254 characters");
     }
 
     @Test
     public void test022__first_DOT_last__No__ATSIGN_() {
-        this.parseFailsWithComment("first.last", "No @");
+        this.parseStringFailsWithComment("first.last", "No @");
     }
 
     @Test
     public void test023__12345678901234567890123456789012345678901234567890123456789012345_ATSIGN_iana_DOT_org__Local_part_more_than_64_characters() {
-        this.parseFailsWithComment("12345678901234567890123456789012345678901234567890123456789012345@iana.org",
+        this.parseStringFailsWithComment("12345678901234567890123456789012345678901234567890123456789012345@iana.org",
                 "Local part more than 64 characters");
     }
 
     @Test
     public void test024___DOT_first_DOT_last_ATSIGN_iana_DOT_org__Local_part_starts_with_a_dot() {
-        this.parseFailsWithComment(".first.last@iana.org", "Local part starts with a dot");
+        this.parseStringFailsWithComment(".first.last@iana.org", "Local part starts with a dot");
     }
 
     @Test
     public void test025__first_DOT_last_DOT__ATSIGN_iana_DOT_org__Local_part_ends_with_a_dot() {
-        this.parseFailsWithComment("first.last.@iana.org", "Local part ends with a dot");
+        this.parseStringFailsWithComment("first.last.@iana.org", "Local part ends with a dot");
     }
 
     @Test
     public void test026__first_DOT__DOT_last_ATSIGN_iana_DOT_org__Local_part_has_consecutive_dots() {
-        this.parseFailsWithComment("first..last@iana.org", "Local part has consecutive dots");
+        this.parseStringFailsWithComment("first..last@iana.org", "Local part has consecutive dots");
     }
 
     @Test
     public void test027__firstlast_ATSIGN_iana_DOT_org__Local_part_contains_unescaped_excluded_characters() {
-        this.parseFailsWithComment("\"first\"last\"@iana.org", "Local part contains unescaped excluded characters");
+        this.parseStringFailsWithComment("\"first\"last\"@iana.org", "Local part contains unescaped excluded characters");
     }
 
     @Test
@@ -455,55 +455,55 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test029___ATSIGN_iana_DOT_org__Local_part_contains_unescaped_excluded_characters() {
-        this.parseFailsWithComment("\"\"\"@iana.org", "Local part contains unescaped excluded characters");
+        this.parseStringFailsWithComment("\"\"\"@iana.org", "Local part contains unescaped excluded characters");
     }
 
     @Test
     public void test030___ATSIGN_iana_DOT_org__Local_part_cannot_end_with_a_backslash() {
-        this.parseFailsWithComment("\"\\\"@iana.org", "Local part cannot end with a backslash");
+        this.parseStringFailsWithComment("\"\\\"@iana.org", "Local part cannot end with a backslash");
     }
 
     @Test
     public void test031___ATSIGN_iana_DOT_org__Local_part_is_effectively_empty() {
-        this.parseFailsWithComment("\"\"@iana.org", "Local part is effectively empty");
+        this.parseStringFailsWithComment("\"\"@iana.org", "Local part is effectively empty");
     }
 
     @Test
     public void test032__first_ATSIGN_last_ATSIGN_iana_DOT_org__Local_part_contains_unescaped_excluded_characters() {
-        this.parseFailsWithComment("first\\\\@last@iana.org", "Local part contains unescaped excluded characters");
+        this.parseStringFailsWithComment("first\\\\@last@iana.org", "Local part contains unescaped excluded characters");
     }
 
     @Test
     public void test033__first_DOT_last_ATSIGN___No_domain() {
-        this.parseFailsWithComment("first.last@", "No domain");
+        this.parseStringFailsWithComment("first.last@", "No domain");
     }
 
     @Test
     public void test034__x_ATSIGN_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456789_DOT_x23456__Domain_exceeds_255_chars() {
-        this.parseFailsWithComment(
+        this.parseStringFailsWithComment(
                 "x@x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456789.x23456",
                 "Domain exceeds 255 chars");
     }
 
     @Test
     public void test035__first_DOT_last_ATSIGN__DOT_12_DOT_34_DOT_56_DOT_78__Only_char_that_can_precede_IPv4_address_is_() {
-        this.parseFailsWithComment("first.last@[.12.34.56.78]", "Only char that can precede IPv4 address is \':\'");
+        this.parseStringFailsWithComment("first.last@[.12.34.56.78]", "Only char that can precede IPv4 address is \':\'");
     }
 
     @Test
     public void test036__first_DOT_last_ATSIGN_12_DOT_34_DOT_56_DOT_789__Cant_be_interpreted_as_IPv4_so_IPv6_tag_is_missing() {
-        this.parseFailsWithComment("first.last@[12.34.56.789]", "Can\'t be interpreted as IPv4 so IPv6 tag is missing");
+        this.parseStringFailsWithComment("first.last@[12.34.56.789]", "Can\'t be interpreted as IPv4 so IPv6 tag is missing");
     }
 
     @Test
     @Disabled
     public void test037__first_DOT_last_ATSIGN_12_DOT_34_DOT_56_DOT_78__IPv6_tag_is_missing() {
-        this.parseFailsWithComment("first.last@[::12.34.56.78]", "IPv6 tag is missing");
+        this.parseStringFailsWithComment("first.last@[::12.34.56.78]", "IPv6 tag is missing");
     }
 
     @Test
     public void test038__first_DOT_last_ATSIGN_IPv512_DOT_34_DOT_56_DOT_78__IPv6_tag_is_wrong() {
-        this.parseFailsWithComment("first.last@[IPv5:::12.34.56.78]", "IPv6 tag is wrong");
+        this.parseStringFailsWithComment("first.last@[IPv5:::12.34.56.78]", "IPv6 tag is wrong");
     }
 
     @Test
@@ -514,27 +514,27 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test040__first_DOT_last_ATSIGN_IPv61111222233334444555512_DOT_34_DOT_56_DOT_78__Not_enough_IPv6_groups() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:12.34.56.78]", "Not enough IPv6 groups");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:12.34.56.78]", "Not enough IPv6 groups");
     }
 
     @Test
     public void test041__first_DOT_last_ATSIGN_IPv6111122223333444455556666777712_DOT_34_DOT_56_DOT_78__Too_many_IPv6_groups__LEFT_PAREN_6_max_RIGHT_PAREN_() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:12.34.56.78]", "Too many IPv6 groups (6 max)");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:12.34.56.78]", "Too many IPv6 groups (6 max)");
     }
 
     @Test
     public void test042__first_DOT_last_ATSIGN_IPv61111222233334444555566667777__Not_enough_IPv6_groups() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777]", "Not enough IPv6 groups");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777]", "Not enough IPv6 groups");
     }
 
     @Test
     public void test043__first_DOT_last_ATSIGN_IPv6111122223333444455556666777788889999__Too_many_IPv6_groups__LEFT_PAREN_8_max_RIGHT_PAREN_() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]", "Too many IPv6 groups (8 max)");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]", "Too many IPv6 groups (8 max)");
     }
 
     @Test
     public void test044__first_DOT_last_ATSIGN_IPv6111122223333444455556666__Too_many___LEFT_PAREN_can_be_none_or_one_RIGHT_PAREN_() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222::3333::4444:5555:6666]", "Too many \'::\' (can be none or one)");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222::3333::4444:5555:6666]", "Too many \'::\' (can be none or one)");
     }
 
     @Test
@@ -545,12 +545,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test046__first_DOT_last_ATSIGN_IPv611112222333x44445555__x_is_not_valid_in_an_IPv6_address() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:333x::4444:5555]", "x is not valid in an IPv6 address");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:333x::4444:5555]", "x is not valid in an IPv6 address");
     }
 
     @Test
     public void test047__first_DOT_last_ATSIGN_IPv6111122223333344445555__33333_is_not_a_valid_group_in_an_IPv6_address() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:33333::4444:5555]", "33333 is not a valid group in an IPv6 address");
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:33333::4444:5555]", "33333 is not a valid group in an IPv6 address");
     }
 
     @Test
@@ -565,17 +565,17 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test050__first_DOT_last_ATSIGN_xample_DOT_com__Label_cant_begin_with_a_hyphen() {
-        this.parseFailsWithComment("first.last@-xample.com", "Label can\'t begin with a hyphen");
+        this.parseStringFailsWithComment("first.last@-xample.com", "Label can\'t begin with a hyphen");
     }
 
     @Test
     public void test051__first_DOT_last_ATSIGN_exampl_DOT_com__Label_cant_end_with_a_hyphen() {
-        this.parseFailsWithComment("first.last@exampl-.com", "Label can\'t end with a hyphen");
+        this.parseStringFailsWithComment("first.last@exampl-.com", "Label can\'t end with a hyphen");
     }
 
     @Test
     public void test052__first_DOT_last_ATSIGN_x234567890123456789012345678901234567890123456789012345678901234_DOT_iana_DOT_org__Label_cant_be_longer_than_63_octets() {
-        this.parseFailsWithComment("first.last@x234567890123456789012345678901234567890123456789012345678901234.iana.org",
+        this.parseStringFailsWithComment("first.last@x234567890123456789012345678901234567890123456789012345678901234.iana.org",
                 "Label can\'t be longer than 63 octets");
     }
 
@@ -636,12 +636,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test064__abc_ATSIGN_def_ATSIGN_iana_DOT_org__This_example_from_RFC_3696_was_corrected_in_an_erratum() {
-        this.parseFailsWithComment("abc\\@def@iana.org", "This example from RFC 3696 was corrected in an erratum");
+        this.parseStringFailsWithComment("abc\\@def@iana.org", "This example from RFC 3696 was corrected in an erratum");
     }
 
     @Test
     public void test065__abc_ATSIGN_iana_DOT_org__This_example_from_RFC_3696_was_corrected_in_an_erratum() {
-        this.parseFailsWithComment("abc\\\\@iana.org", "This example from RFC 3696 was corrected in an erratum");
+        this.parseStringFailsWithComment("abc\\\\@iana.org", "This example from RFC 3696 was corrected in an erratum");
     }
 
     @Test
@@ -651,7 +651,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test067__Doug_Ace_Lovell_ATSIGN_iana_DOT_org__Escaping_can_only_happen_in_a_quoted_string() {
-        this.parseFailsWithComment("Doug\\ \\\"Ace\\\"\\ Lovell@iana.org", "Escaping can only happen in a quoted string");
+        this.parseStringFailsWithComment("Doug\\ \\\"Ace\\\"\\ Lovell@iana.org", "Escaping can only happen in a quoted string");
     }
 
     @Test
@@ -661,73 +661,73 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test069__abc_ATSIGN_def_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("abc@def@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("abc@def@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test070__abc_ATSIGN_def_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("abc\\\\@def@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("abc\\\\@def@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test071__abc_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("abc\\@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("abc\\@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test072___ATSIGN_iana_DOT_org__No_local_part() {
-        this.parseFailsWithComment("@iana.org", "No local part");
+        this.parseStringFailsWithComment("@iana.org", "No local part");
     }
 
     @Test
     public void test073__doug_ATSIGN___Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("doug@", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("doug@", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test074__qu_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("\"qu@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("\"qu@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test075__ote_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("ote\"@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("ote\"@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test076___DOT_dot_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment(".dot@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment(".dot@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test077__dot_DOT__ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("dot.@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("dot.@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test078__two_DOT__DOT_dot_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("two..dot@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("two..dot@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     @Disabled
     public void test079__Doug_Ace_L_DOT__ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("\"Doug \"Ace\" L.\"@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("\"Doug \"Ace\" L.\"@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test080__Doug_Ace_L_DOT__ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("Doug\\ \\\"Ace\\\"\\ L\\.@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("Doug\\ \\\"Ace\\\"\\ L\\.@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test081__hello_world_ATSIGN_iana_DOT_org__Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("hello world@iana.org", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("hello world@iana.org", "Doug Lovell says this should fail");
     }
 
     @Test
     public void test082__gatsby_ATSIGN_f_DOT_sc_DOT_ot_DOT_t_DOT_f_DOT_i_DOT_tzg_DOT_era_DOT_l_DOT_d_DOT___Doug_Lovell_says_this_should_fail() {
-        this.parseFailsWithComment("gatsby@f.sc.ot.t.f.i.tzg.era.l.d.", "Doug Lovell says this should fail");
+        this.parseStringFailsWithComment("gatsby@f.sc.ot.t.f.i.tzg.era.l.d.", "Doug Lovell says this should fail");
     }
 
     @Test
@@ -823,42 +823,42 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test101__test_DOT_iana_DOT_org() {
-        this.parseFailsWithComment("test.iana.org");
+        this.parseStringFailsWithComment("test.iana.org");
     }
 
     @Test
     public void test102__test_DOT__ATSIGN_iana_DOT_org() {
-        this.parseFailsWithComment("test.@iana.org");
+        this.parseStringFailsWithComment("test.@iana.org");
     }
 
     @Test
     public void test103__test_DOT__DOT_test_ATSIGN_iana_DOT_org() {
-        this.parseFailsWithComment("test..test@iana.org");
+        this.parseStringFailsWithComment("test..test@iana.org");
     }
 
     @Test
     public void test104___DOT_test_ATSIGN_iana_DOT_org() {
-        this.parseFailsWithComment(".test@iana.org");
+        this.parseStringFailsWithComment(".test@iana.org");
     }
 
     @Test
     public void test105__test_ATSIGN_test_ATSIGN_iana_DOT_org() {
-        this.parseFailsWithComment("test@test@iana.org");
+        this.parseStringFailsWithComment("test@test@iana.org");
     }
 
     @Test
     public void test106__test_ATSIGN__ATSIGN_iana_DOT_org() {
-        this.parseFailsWithComment("test@@iana.org");
+        this.parseStringFailsWithComment("test@@iana.org");
     }
 
     @Test
     public void test107___test__ATSIGN_iana_DOT_org__No_spaces_allowed_in_local_part() {
-        this.parseFailsWithComment("-- test --@iana.org", "No spaces allowed in local part");
+        this.parseStringFailsWithComment("-- test --@iana.org", "No spaces allowed in local part");
     }
 
     @Test
     public void test108__test_ATSIGN_iana_DOT_org__Square_brackets_only_allowed_within_quotes() {
-        this.parseFailsWithComment("[test]@iana.org", "Square brackets only allowed within quotes");
+        this.parseStringFailsWithComment("[test]@iana.org", "Square brackets only allowed within quotes");
     }
 
     @Test
@@ -868,27 +868,27 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test110__testtest_ATSIGN_iana_DOT_org__Quotes_cannot_be_nested() {
-        this.parseFailsWithComment("\"test\"test\"@iana.org", "Quotes cannot be nested");
+        this.parseStringFailsWithComment("\"test\"test\"@iana.org", "Quotes cannot be nested");
     }
 
     @Test
     public void test112__test_ATSIGN__DOT___Dave_Child_says_so() {
-        this.parseFailsWithComment("test@.", "Dave Child says so");
+        this.parseStringFailsWithComment("test@.", "Dave Child says so");
     }
 
     @Test
     public void test113__test_ATSIGN_example_DOT___Dave_Child_says_so() {
-        this.parseFailsWithComment("test@example.", "Dave Child says so");
+        this.parseStringFailsWithComment("test@example.", "Dave Child says so");
     }
 
     @Test
     public void test114__test_ATSIGN__DOT_org__Dave_Child_says_so() {
-        this.parseFailsWithComment("test@.org", "Dave Child says so");
+        this.parseStringFailsWithComment("test@.org", "Dave Child says so");
     }
 
     @Test
     public void test115__test_ATSIGN_123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012_DOT_com__255_characters_is_maximum_length_for_domain_DOT__This_is_256_DOT_() {
-        this.parseFailsWithComment(
+        this.parseStringFailsWithComment(
                 "test@123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012.com",
                 "255 characters is maximum length for domain. This is 256.");
     }
@@ -900,22 +900,22 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test117__test_ATSIGN_123_DOT_123_DOT_123_DOT_123__Dave_Child_says_so() {
-        this.parseFailsWithComment("test@[123.123.123.123", "Dave Child says so");
+        this.parseStringFailsWithComment("test@[123.123.123.123", "Dave Child says so");
     }
 
     @Test
     public void test118__test_ATSIGN_123_DOT_123_DOT_123_DOT_123__Dave_Child_says_so() {
-        this.parseFailsWithComment("test@123.123.123.123]", "Dave Child says so");
+        this.parseStringFailsWithComment("test@123.123.123.123]", "Dave Child says so");
     }
 
     @Test
     public void test119__NotAnEmail__Phil_Haack_says_so() {
-        this.parseFailsWithComment("NotAnEmail", "Phil Haack says so");
+        this.parseStringFailsWithComment("NotAnEmail", "Phil Haack says so");
     }
 
     @Test
     public void test120___ATSIGN_NotAnEmail__Phil_Haack_says_so() {
-        this.parseFailsWithComment("@NotAnEmail", "Phil Haack says so");
+        this.parseStringFailsWithComment("@NotAnEmail", "Phil Haack says so");
     }
 
     @Test
@@ -936,7 +936,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     @Test
     @Disabled
     public void test124__testblah_ATSIGN_iana_DOT_org__Quoted_string_specifically_excludes_carriage_returns() {
-        this.parseFailsWithComment("\"test\rblah\"@iana.org", "Quoted string specifically excludes carriage returns");
+        this.parseStringFailsWithComment("\"test\rblah\"@iana.org", "Quoted string specifically excludes carriage returns");
     }
 
     @Test
@@ -946,7 +946,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test126__testblah_ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment("\"test\"blah\"@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment("\"test\"blah\"@iana.org", "Phil Haack says so");
     }
 
     @Test
@@ -966,22 +966,22 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test130___DOT_wooly_ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment(".wooly@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment(".wooly@iana.org", "Phil Haack says so");
     }
 
     @Test
     public void test131__wo_DOT__DOT_oly_ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment("wo..oly@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment("wo..oly@iana.org", "Phil Haack says so");
     }
 
     @Test
     public void test132__pootietang_DOT__ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment("pootietang.@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment("pootietang.@iana.org", "Phil Haack says so");
     }
 
     @Test
     public void test133___DOT__ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment(".@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment(".@iana.org", "Phil Haack says so");
     }
 
     @Test
@@ -1006,12 +1006,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test138__Ima_Fool_ATSIGN_iana_DOT_org__Phil_Haack_says_so() {
-        this.parseFailsWithComment("Ima Fool@iana.org", "Phil Haack says so");
+        this.parseStringFailsWithComment("Ima Fool@iana.org", "Phil Haack says so");
     }
 
     @Test
     public void test139__phil_DOT_h_ATSIGN__ATSIGN_ck_ATSIGN_haacked_DOT_com__Escaping_can_only_happen_in_a_quoted_string() {
-        this.parseFailsWithComment("phil.h\\@\\@ck@haacked.com", "Escaping can only happen in a quoted string");
+        this.parseStringFailsWithComment("phil.h\\@\\@ck@haacked.com", "Escaping can only happen in a quoted string");
     }
 
     @Test
@@ -1026,7 +1026,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test142__firstlast_ATSIGN_iana_DOT_org__Contains_an_unescaped_quote() {
-        this.parseFailsWithComment("\"first\\\\\"last\"@iana.org", "Contains an unescaped quote");
+        this.parseStringFailsWithComment("\"first\\\\\"last\"@iana.org", "Contains an unescaped quote");
     }
 
     @Test
@@ -1061,7 +1061,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test149__foo_ATSIGN_1_DOT_2_DOT_3_DOT_4__RFC_5321_specifies_the_syntax_for_addressliteral_and_does_not_allow_escaping() {
-        this.parseFailsWithComment("foo@[\\1.2.3.4]", "RFC 5321 specifies the syntax for address-literal and does not allow escaping");
+        this.parseStringFailsWithComment("foo@[\\1.2.3.4]", "RFC 5321 specifies the syntax for address-literal and does not allow escaping");
     }
 
     @Test
@@ -1082,39 +1082,39 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test153__first_DOT__DOT_last_ATSIGN_iana_DOT_org__Contains_a_zerolength_element() {
-        this.parseFailsWithComment("first.\"\".last@iana.org", "Contains a zero-length element");
+        this.parseStringFailsWithComment("first.\"\".last@iana.org", "Contains a zero-length element");
     }
 
     @Test
     public void test154__firstlast_ATSIGN_iana_DOT_org__Unquoted_string_must_be_an_atom() {
-        this.parseFailsWithComment("first\\last@iana.org", "Unquoted string must be an atom");
+        this.parseStringFailsWithComment("first\\last@iana.org", "Unquoted string must be an atom");
     }
 
     @Test
     public void test155__Abc_ATSIGN_def_ATSIGN_iana_DOT_org__Was_incorrectly_given_as_a_valid_address_in_the_original_RFC_3696() {
-        this.parseFailsWithComment("Abc\\@def@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
+        this.parseStringFailsWithComment("Abc\\@def@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
     }
 
     @Test
     public void test156__Fred_Bloggs_ATSIGN_iana_DOT_org__Was_incorrectly_given_as_a_valid_address_in_the_original_RFC_3696() {
-        this.parseFailsWithComment("Fred\\ Bloggs@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
+        this.parseStringFailsWithComment("Fred\\ Bloggs@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
     }
 
     @Test
     public void test157__Joe_DOT_Blow_ATSIGN_iana_DOT_org__Was_incorrectly_given_as_a_valid_address_in_the_original_RFC_3696() {
-        this.parseFailsWithComment("Joe.\\\\Blow@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
+        this.parseStringFailsWithComment("Joe.\\\\Blow@iana.org", "Was incorrectly given as a valid address in the original RFC 3696");
     }
 
     @Test
     public void test158__first_DOT_last_ATSIGN_IPv611112222333344445555666612_DOT_34_DOT_567_DOT_89__IPv4_part_contains_an_invalid_octet() {
-        this.parseFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.567.89]",
+        this.parseStringFailsWithComment("first.last@[IPv6:1111:2222:3333:4444:5555:6666:12.34.567.89]",
                 "IPv4 part contains an invalid octet");
     }
 
     @Test
     @Disabled
     public void test159__test_blah_ATSIGN_iana_DOT_org__Folding_white_space_cant_appear_within_a_quoted_pair() {
-        this.parseFailsWithComment("\"test\\\r\n blah\"@iana.org", "Folding white space can\'t appear within a quoted pair");
+        this.parseStringFailsWithComment("\"test\\\r\n blah\"@iana.org", "Folding white space can\'t appear within a quoted pair");
     }
 
     @Test
@@ -1124,7 +1124,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test161__c_ATSIGN_Dog_ATSIGN_cartoon_DOT_com__This_is_a_throwaway_example_from_Doug_Lovells_article_DOT__Actually_its_not_a_valid_address_DOT_() {
-        this.parseFailsWithComment("{^c\\@**Dog^}@cartoon.com",
+        this.parseStringFailsWithComment("{^c\\@**Dog^}@cartoon.com",
                 "This is a throwaway example from Doug Lovell\'s article. Actually it\'s not a valid address.");
     }
 
@@ -1135,7 +1135,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test189___DOT__ATSIGN_() {
-        this.parseFailsWithComment(".@");
+        this.parseStringFailsWithComment(".@");
     }
 
     @Test
@@ -1145,12 +1145,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test191___ATSIGN_bar_DOT_com() {
-        this.parseFailsWithComment("@bar.com");
+        this.parseStringFailsWithComment("@bar.com");
     }
 
     @Test
     public void test192___ATSIGN__ATSIGN_bar_DOT_com() {
-        this.parseFailsWithComment("@@bar.com");
+        this.parseStringFailsWithComment("@@bar.com");
     }
 
     @Test
@@ -1160,17 +1160,17 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test194__aaa_DOT_com() {
-        this.parseFailsWithComment("aaa.com");
+        this.parseStringFailsWithComment("aaa.com");
     }
 
     @Test
     public void test195__aaa_ATSIGN__DOT_com() {
-        this.parseFailsWithComment("aaa@.com");
+        this.parseStringFailsWithComment("aaa@.com");
     }
 
     @Test
     public void test196__aaa_ATSIGN__DOT_123() {
-        this.parseFailsWithComment("aaa@.123");
+        this.parseStringFailsWithComment("aaa@.123");
     }
 
     @Test
@@ -1180,17 +1180,17 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test198__aaa_ATSIGN_123_DOT_123_DOT_123_DOT_123a__extra_data_outside_ip() {
-        this.parseFailsWithComment("aaa@[123.123.123.123]a", "extra data outside ip");
+        this.parseStringFailsWithComment("aaa@[123.123.123.123]a", "extra data outside ip");
     }
 
     @Test
     public void test199__aaa_ATSIGN_123_DOT_123_DOT_123_DOT_333__not_a_valid_IP() {
-        this.parseFailsWithComment("aaa@[123.123.123.333]", "not a valid IP");
+        this.parseStringFailsWithComment("aaa@[123.123.123.333]", "not a valid IP");
     }
 
     @Test
     public void test200__a_ATSIGN_bar_DOT_com_DOT_() {
-        this.parseFailsWithComment("a@bar.com.");
+        this.parseStringFailsWithComment("a@bar.com.");
     }
 
     @Test
@@ -1215,22 +1215,22 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test205__a_ATSIGN_b_DOT_com() {
-        this.parseFailsWithComment("a@-b.com");
+        this.parseStringFailsWithComment("a@-b.com");
     }
 
     @Test
     public void test206__a_ATSIGN_b_DOT_com() {
-        this.parseFailsWithComment("a@b-.com");
+        this.parseStringFailsWithComment("a@b-.com");
     }
 
     @Test
     public void test207___ATSIGN__DOT__DOT_com() {
-        this.parseFailsWithComment("-@..com");
+        this.parseStringFailsWithComment("-@..com");
     }
 
     @Test
     public void test208___ATSIGN_a_DOT__DOT_com() {
-        this.parseFailsWithComment("-@a..com");
+        this.parseStringFailsWithComment("-@a..com");
     }
 
     @Test
@@ -1255,7 +1255,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test213__invalid_ATSIGN_about_DOT_museum() {
-        this.parseFailsWithComment("invalid@about.museum-");
+        this.parseStringFailsWithComment("invalid@about.museum-");
     }
 
     @Test
@@ -1265,7 +1265,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test215__test_ATSIGN__DOT__DOT__DOT__DOT__DOT__DOT__DOT__DOT__DOT__DOT__DOT_com___DOT__DOT__DOT__DOT__DOT__DOT_() {
-        this.parseFailsWithComment("test@...........com", "......");
+        this.parseStringFailsWithComment("test@...........com", "......");
     }
 
     @Test
@@ -1280,7 +1280,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test218__Invalid__Folding__Whitespace_ATSIGN_iana_DOT_org__This_isnt_FWS_so_Dominic_Sayers_says_its_invalid() {
-        this.parseFailsWithComment("Invalid \\\n Folding \\\n Whitespace@iana.org",
+        this.parseStringFailsWithComment("Invalid \\\n Folding \\\n Whitespace@iana.org",
                 "This isn\'t FWS so Dominic Sayers says it\'s invalid");
     }
 
@@ -1304,7 +1304,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test225__test_DOT__obs_ATSIGN_syntax_DOT_com__obsfws_must_have_at_least_one_WSP_per_line() {
-        this.parseFailsWithComment("test.\r\n\r\n obs@syntax.com", "obs-fws must have at least one WSP per line");
+        this.parseStringFailsWithComment("test.\r\n\r\n obs@syntax.com", "obs-fws must have at least one WSP per line");
     }
 
     @Test
@@ -1315,12 +1315,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     @Test
     @Disabled
     public void test227__Unicode_NULL__ATSIGN_char_DOT_com__Cannot_have_unescaped_Unicode_Character_NULL__LEFT_PAREN_U0000_RIGHT_PAREN_() {
-        this.parseFailsWithComment("\"Unicode NULL \0\"@char.com", "Cannot have unescaped Unicode Character \'NULL\' (U+0000)");
+        this.parseStringFailsWithComment("\"Unicode NULL \0\"@char.com", "Cannot have unescaped Unicode Character \'NULL\' (U+0000)");
     }
 
     @Test
     public void test228__Unicode_NULL__ATSIGN_char_DOT_com__Escaped_Unicode_Character_NULL__LEFT_PAREN_U0000_RIGHT_PAREN__must_be_in_quoted_string() {
-        this.parseFailsWithComment("Unicode NULL \\\0@char.com",
+        this.parseStringFailsWithComment("Unicode NULL \\\0@char.com",
                 "Escaped Unicode Character \'NULL\' (U+0000) must be in quoted string");
     }
 
@@ -1343,7 +1343,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test232__first_DOT_last_ATSIGN_IPv6__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1353,12 +1353,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test234__first_DOT_last_ATSIGN_IPv6__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::::]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::::]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test235__first_DOT_last_ATSIGN_IPv6b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1368,12 +1368,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test237__first_DOT_last_ATSIGN_IPv6b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::::b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::::b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test238__first_DOT_last_ATSIGN_IPv6b3b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::b3:b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::b3:b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1383,7 +1383,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test240__first_DOT_last_ATSIGN_IPv6b3b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::::b3:b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::::b3:b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1393,12 +1393,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test242__first_DOT_last_ATSIGN_IPv6a1b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:::b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:::b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test243__first_DOT_last_ATSIGN_IPv6a1__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1408,12 +1408,12 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test245__first_DOT_last_ATSIGN_IPv6a1__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:::]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:::]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test246__first_DOT_last_ATSIGN_IPv6a1a2__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:a2:]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:a2:]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1423,7 +1423,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test248__first_DOT_last_ATSIGN_IPv6a1a2__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:a2:::]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:a2:::]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1460,17 +1460,17 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test255__first_DOT_last_ATSIGN_IPv611_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test256__first_DOT_last_ATSIGN_IPv611_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test257__first_DOT_last_ATSIGN_IPv6a111_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1480,7 +1480,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test259__first_DOT_last_ATSIGN_IPv6a111_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1490,7 +1490,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test261__first_DOT_last_ATSIGN_IPv6a1a211_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:a2:::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:a2:::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1500,7 +1500,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test263__first_DOT_last_ATSIGN_IPv60123456789abcdef11_DOT_22_DOT_33_DOT_xx__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.xx]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:0123:4567:89ab:cdef::11.22.33.xx]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1510,27 +1510,27 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test265__first_DOT_last_ATSIGN_IPv60123456789abCDEFF11_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:0123:4567:89ab:CDEFF::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:0123:4567:89ab:CDEFF::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test266__first_DOT_last_ATSIGN_IPv6a1a4b1b411_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::a4:b1::b4:11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::a4:b1::b4:11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test267__first_DOT_last_ATSIGN_IPv6a111_DOT_22_DOT_33__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::11.22.33]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::11.22.33]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test268__first_DOT_last_ATSIGN_IPv6a111_DOT_22_DOT_33_DOT_44_DOT_55__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::11.22.33.44.55]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::11.22.33.44.55]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test269__first_DOT_last_ATSIGN_IPv6a1b211_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::b211.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::b211.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1540,32 +1540,32 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void test271__first_DOT_last_ATSIGN_IPv6a1b211_DOT_22_DOT_33_DOT_44__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::b2::11.22.33.44]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::b2::11.22.33.44]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test272__first_DOT_last_ATSIGN_IPv6a1b3__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1::b3:]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1::b3:]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test273__first_DOT_last_ATSIGN_IPv6a2b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::a2::b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::a2::b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test274__first_DOT_last_ATSIGN_IPv6a1a2a3a4b1b2b3__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3:]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:a2:a3:a4:b1:b2:b3:]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test275__first_DOT_last_ATSIGN_IPv6a2a3a4b1b2b3b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6::a2:a3:a4:b1:b2:b3:b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6::a2:a3:a4:b1:b2:b3:b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
     public void test276__first_DOT_last_ATSIGN_IPv6a1a2a3a4b1b2b3b4__IPv6_authority_is_RFC_4291() {
-        this.parseFailsWithComment("first.last@[IPv6:a1:a2:a3:a4::b1:b2:b3:b4]", "IPv6 authority is RFC 4291");
+        this.parseStringFailsWithComment("first.last@[IPv6:a1:a2:a3:a4::b1:b2:b3:b4]", "IPv6 authority is RFC 4291");
     }
 
     @Test
@@ -1576,7 +1576,7 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     @Test
     @Disabled
     public void test278__test_ATSIGN_example_DOT_com__Address_has_a_newline_at_the_end() {
-        this.parseFailsWithComment("test@example.com", "Address has a newline at the end");
+        this.parseStringFailsWithComment("test@example.com", "Address has a newline at the end");
     }
 
     @Test
@@ -1607,13 +1607,13 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
         }
     }
 
-    private void parseFailsWithComment(final String address) {
-        this.parseFailsWithComment(address, null);
+    private void parseStringFailsWithComment(final String address) {
+        this.parseStringFailsWithComment(address, null);
     }
 
-    private void parseFailsWithComment(final String address, final String comment) {
+    private void parseStringFailsWithComment(final String address, final String comment) {
         assertThrows(RuntimeException.class, () -> {
-            this.parse(address);
+            this.parseString(address);
         }, "Invalid email " + CharSequences.quoteAndEscape(address) + " should have failed="
                 + this.makeEmptyIfNull(comment));
 
@@ -1730,17 +1730,17 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     // ParseStringTesting ..................................................................................................
 
     @Override
-    public EmailAddress parse(final String text) {
+    public EmailAddress parseString(final String text) {
         return EmailAddress.parse(text);
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderValueParserTest.java
@@ -30,324 +30,324 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testParameterSeparatorFails() {
-        this.parseMissingValueFails(";", 0);
+        this.parseStringMissingValueFails(";", 0);
     }
 
     @Test
     public void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testCharsetSeparatorFails() {
-        this.parseMissingValueFails("utf-8,");
+        this.parseStringMissingValueFails("utf-8,");
     }
 
     @Test
     public void testCharsetSeparatorSpaceFails() {
-        this.parseFails("utf-8, ", "Missing charset at 7 in \"utf-8, \"");
+        this.parseStringFails("utf-8, ", "Missing charset at 7 in \"utf-8, \"");
     }
 
     @Test
     public void testCharsetSeparatorTabFails() {
-        this.parseFails("utf-8,\t", "Missing charset at 7 in \"utf-8,\\t\"");
+        this.parseStringFails("utf-8,\t", "Missing charset at 7 in \"utf-8,\\t\"");
     }
 
     @Test
     public void testCharsetInvalidInitialCharacterFails() {
-        this.parseInvalidCharacterFails("!utf-8", '!');
+        this.parseStringInvalidCharacterFails("!utf-8", '!');
     }
 
     @Test
     public void testCharsetInvalidPartCharacterFails() {
-        this.parseInvalidCharacterFails("utf\08", '\0');
+        this.parseStringInvalidCharacterFails("utf\08", '\0');
     }
 
     @Test
     public void testCharset() {
-        this.parseAndCheck("utf-8", "utf-8");
+        this.parseStringAndCheck("utf-8", "utf-8");
     }
 
     @Test
     public void testCharsetInvalidCharacterFails2() {
-        this.parseInvalidCharacterFails("UTF-8BC<");
+        this.parseStringInvalidCharacterFails("UTF-8BC<");
     }
 
     @Test
     public void testWildcard() {
-        this.parseAndCheck("*", CharsetHeaderValue.WILDCARD_VALUE);
+        this.parseStringAndCheck("*", CharsetHeaderValue.WILDCARD_VALUE);
     }
 
     @Test
     public void testWildcardInvalidFails() {
-        this.parseInvalidCharacterFails("*1");
+        this.parseStringInvalidCharacterFails("*1");
     }
 
     @Test
     public void testWildcardInvalidFails2() {
-        this.parseInvalidCharacterFails("*u");
+        this.parseStringInvalidCharacterFails("*u");
     }
 
     @Test
     public void testWildcardWildcardFails() {
-        this.parseInvalidCharacterFails("**");
+        this.parseStringInvalidCharacterFails("**");
     }
 
     @Test
     public void testCharsetEqualsFails() {
-        this.parseMissingParameterValueFails("UTF-8;b=");
+        this.parseStringMissingParameterValueFails("UTF-8;b=");
     }
 
     @Test
     public void testCharsetSpaceEqualsFails() {
-        this.parseMissingParameterValueFails("UTF-8;b =");
+        this.parseStringMissingParameterValueFails("UTF-8;b =");
     }
 
     @Test
     public void testCharsetTabEqualsFails() {
-        this.parseMissingParameterValueFails("UTF-8;b =");
+        this.parseStringMissingParameterValueFails("UTF-8;b =");
     }
 
     @Test
     public void testCharsetSpaceTabSpaceTabEqualsFails() {
-        this.parseMissingParameterValueFails("UTF-8;b \t \t=");
+        this.parseStringMissingParameterValueFails("UTF-8;b \t \t=");
     }
 
     @Test
     public void testCharsetEqualsSpaceFails() {
-        this.parseMissingParameterValueFails("UTF-8;b= ");
+        this.parseStringMissingParameterValueFails("UTF-8;b= ");
     }
 
     @Test
     public void testCharsetEqualsTabFails() {
-        this.parseMissingParameterValueFails("UTF-8;b=\t");
+        this.parseStringMissingParameterValueFails("UTF-8;b=\t");
     }
 
     @Test
     public void testCharsetEqualsCrNlSpaceFails() {
-        this.parseMissingParameterValueFails("UTF-8;b=\r\n ");
+        this.parseStringMissingParameterValueFails("UTF-8;b=\r\n ");
     }
 
     @Test
     public void testCharsetEqualsCrNlTabFails() {
-        this.parseMissingParameterValueFails("UTF-8;b=\r\n\t");
+        this.parseStringMissingParameterValueFails("UTF-8;b=\r\n\t");
     }
 
     @Test
     public void testCharsetParameterTokenSeparatorTokenSeparatorFails() {
-        this.parseInvalidCharacterFails("UTF-8;;", 6);
+        this.parseStringInvalidCharacterFails("UTF-8;;", 6);
     }
 
     @Test
     public void testCharset2() {
-        this.parseAndCheck("utf-16", "utf-16");
+        this.parseStringAndCheck("utf-16", "utf-16");
     }
 
     @Test
     public void testCharsetSpace() {
-        this.parseAndCheck("utf-8 ", "utf-8");
+        this.parseStringAndCheck("utf-8 ", "utf-8");
     }
 
     @Test
     public void testCharsetTab() {
-        this.parseAndCheck("utf-8\t", "utf-8");
+        this.parseStringAndCheck("utf-8\t", "utf-8");
     }
 
     @Test
     public void testCharsetCrNlSpace() {
-        this.parseAndCheck("utf-8\r\n ", "utf-8");
+        this.parseStringAndCheck("utf-8\r\n ", "utf-8");
     }
 
     @Test
     public void testCharsetCrNlTab() {
-        this.parseAndCheck("utf-8\r\n\t", "utf-8");
+        this.parseStringAndCheck("utf-8\r\n\t", "utf-8");
     }
 
     @Test
     public void testCharsetSpaceTabCrNlSpaceTab() {
-        this.parseAndCheck("UTF-8 \t\r\n \t", "UTF-8");
+        this.parseStringAndCheck("UTF-8 \t\r\n \t", "UTF-8");
     }
 
     @Test
     public void testCharsetSeparator() {
-        this.parseAndCheck("UTF-8;", "UTF-8");
+        this.parseStringAndCheck("UTF-8;", "UTF-8");
     }
 
     @Test
     public void testCharsetSeparatorSpace() {
-        this.parseAndCheck("UTF-8; ", "UTF-8");
+        this.parseStringAndCheck("UTF-8; ", "UTF-8");
     }
 
     @Test
     public void testCharsetSeparatorTab() {
-        this.parseAndCheck("UTF-8;\t", "UTF-8");
+        this.parseStringAndCheck("UTF-8;\t", "UTF-8");
     }
 
     @Test
     public void testCharsetParameterSeparatorFails() {
-        this.parseInvalidCharacterFails("UTF-8;=", 6);
+        this.parseStringInvalidCharacterFails("UTF-8;=", 6);
     }
 
     @Test
     public void testCharsetParameterNameInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b>=c", '>');
+        this.parseStringInvalidCharacterFails("UTF-8;b>=c", '>');
     }
 
     @Test
     public void testCharsetParameterNameSpaceInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b >=c", '>');
+        this.parseStringInvalidCharacterFails("UTF-8;b >=c", '>');
     }
 
     @Test
     public void testCharsetParameterNameTabInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b\t>=c", '>');
+        this.parseStringInvalidCharacterFails("UTF-8;b\t>=c", '>');
     }
 
     @Test
     public void testCharsetParameterNameEqualsInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b=\0c", '\0');
+        this.parseStringInvalidCharacterFails("UTF-8;b=\0c", '\0');
     }
 
     @Test
     public void testCharsetParameterNameEqualsParameterValue() {
-        this.parseAndCheck("UTF-8;b=c",
+        this.parseStringAndCheck("UTF-8;b=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameSpaceEqualsParameterValue() {
-        this.parseAndCheck("UTF-8;b =c",
+        this.parseStringAndCheck("UTF-8;b =c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameTabEqualsParameterValue() {
-        this.parseAndCheck("UTF-8;b\t=c",
+        this.parseStringAndCheck("UTF-8;b\t=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameSpaceTabSpaceTabEqualsParameterValue() {
-        this.parseAndCheck("UTF-8;b \t \t=c",
+        this.parseStringAndCheck("UTF-8;b \t \t=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameEqualsSpaceParameterValue() {
-        this.parseAndCheck("UTF-8;b= c",
+        this.parseStringAndCheck("UTF-8;b= c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameEqualsTabParameterValue() {
-        this.parseAndCheck("UTF-8;b=\tc",
+        this.parseStringAndCheck("UTF-8;b=\tc",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterNameEqualsSpaceTabSpaceTabParameterValue() {
-        this.parseAndCheck("UTF-8;b= \t \tc",
+        this.parseStringAndCheck("UTF-8;b= \t \tc",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterValueInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b=c>", '>');
+        this.parseStringInvalidCharacterFails("UTF-8;b=c>", '>');
     }
 
     @Test
     public void testCharsetParameterValueSpaceInvalidCharFails() {
-        this.parseInvalidCharacterFails("UTF-8;b=c Q", 'Q');
+        this.parseStringInvalidCharacterFails("UTF-8;b=c Q", 'Q');
     }
 
     @Test
     public void testCharsetParameterValueSpaceInvalidCharFails2() {
-        this.parseInvalidCharacterFails("UTF-8;b=c >", '>');
+        this.parseStringInvalidCharacterFails("UTF-8;b=c >", '>');
     }
 
     @Test
     public void testCharsetParameterSpace() {
-        this.parseAndCheck("UTF-8;bcd=123 ",
+        this.parseStringAndCheck("UTF-8;bcd=123 ",
                 "UTF-8",
                 "bcd", "123");
     }
 
     @Test
     public void testCharsetParameterSeparator() {
-        this.parseAndCheck("UTF-8;bcd=123;",
+        this.parseStringAndCheck("UTF-8;bcd=123;",
                 "UTF-8",
                 "bcd", "123");
     }
 
     @Test
     public void testCharsetParameterTab() {
-        this.parseAndCheck("UTF-8;bcd=123\t",
+        this.parseStringAndCheck("UTF-8;bcd=123\t",
                 "UTF-8",
                 "bcd", "123");
     }
 
     @Test
     public void testCharsetParameterSpaceTabSpaceTab() {
-        this.parseAndCheck("UTF-8;bcd=123 \t \t",
+        this.parseStringAndCheck("UTF-8;bcd=123 \t \t",
                 "UTF-8",
                 "bcd", "123");
     }
 
     @Test
     public void testCharsetParameterSeparatorSpaceParameter() {
-        this.parseAndCheck("UTF-8; b=c",
+        this.parseStringAndCheck("UTF-8; b=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetParameterSeparatorTabParameter() {
-        this.parseAndCheck("UTF-8;\tb=c",
+        this.parseStringAndCheck("UTF-8;\tb=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetSpaceParameterSeparatorParameter() {
-        this.parseAndCheck("UTF-8 ;b=c",
+        this.parseStringAndCheck("UTF-8 ;b=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetSpaceParameterSeparatorSpaceParameter() {
-        this.parseAndCheck("UTF-8 ; b=c",
+        this.parseStringAndCheck("UTF-8 ; b=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetTabParameterSeparatorTabParameter() {
-        this.parseAndCheck("UTF-8\t;\tb=c",
+        this.parseStringAndCheck("UTF-8\t;\tb=c",
                 "UTF-8",
                 "b", "c");
     }
 
     @Test
     public void testCharsetSpaceTabSpaceTabParameterSeparatorSpaceTabParameter() {
-        this.parseAndCheck("UTF-8 \t \t; \t \tb=c",
+        this.parseStringAndCheck("UTF-8 \t \t; \t \tb=c",
                 "UTF-8",
                 "b", "c");
     }
@@ -355,31 +355,31 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
     @Test
     public void testCharsetParameterNameQuotedParameterValueQuotedParameterValueFails() {
         final String text = "UTF-8;b=\"c\"\"d\"";
-        this.parseInvalidCharacterFails(text, text.indexOf('d') - 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('d') - 1);
     }
 
     @Test
     public void testCharsetParameterSeparatorParameterNameFails() {
-        this.parseMissingParameterValueFails("UTF-8;b=c;D");
+        this.parseStringMissingParameterValueFails("UTF-8;b=c;D");
     }
 
     @Test
     public void testCharsetParameter() {
-        this.parseAndCheck("utf-8;p1=v1;",
+        this.parseStringAndCheck("utf-8;p1=v1;",
                 "utf-8",
                 "p1", "v1");
     }
 
     @Test
     public void testCharsetParameterQuotedValue() {
-        this.parseAndCheck("utf-8;p1=\"v1\";",
+        this.parseStringAndCheck("utf-8;p1=\"v1\";",
                 "utf-8",
                 "p1", "v1");
     }
 
     @Test
     public void testCharsetParameterSeparatorParameter() {
-        this.parseAndCheck("utf-8;p1=v1;p2=v2",
+        this.parseStringAndCheck("utf-8;p1=v1;p2=v2",
                 "utf-8",
                 "p1", "v1",
                 "p2", "v2");
@@ -387,7 +387,7 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testCharsetParameterWhitespaceSeparatorParameter() {
-        this.parseAndCheck("utf-8;p1=v1 ;p2=v2",
+        this.parseStringAndCheck("utf-8;p1=v1 ;p2=v2",
                 "utf-8",
                 "p1", "v1",
                 "p2", "v2");
@@ -395,7 +395,7 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testCharsetParameterParameterSeparatorWhitespaceParameter() {
-        this.parseAndCheck("utf-8;p1=v1; p2=v2",
+        this.parseStringAndCheck("utf-8;p1=v1; p2=v2",
                 "utf-8",
                 "p1", "v1",
                 "p2", "v2");
@@ -403,7 +403,7 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testCharsetSeparatorCharset() {
-        this.parseAndCheck("utf-8,utf-16;",
+        this.parseStringAndCheck("utf-8,utf-16;",
                 this.charsetHeaderValue("utf-8"),
                 this.charsetHeaderValue("utf-16"));
     }
@@ -412,13 +412,13 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testQInvalidValueFails() {
-        this.parseFails("utf-8; q=X",
+        this.parseStringFails("utf-8; q=X",
                 "Failed to convert \"q\" value \"X\", message: For input string: \"X\"");
     }
 
     @Test
     public void testQ() {
-        this.parseAndCheck("utf-8; q=0.75",
+        this.parseStringAndCheck("utf-8; q=0.75",
                 "utf-8",
                 "q",
                 0.75f);
@@ -426,7 +426,7 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
 
     @Test
     public void testCharsetSeparatorCharsetQSorted() {
-        this.parseAndCheck("utf-8; q=0.5, utf-16; q=0.75",
+        this.parseStringAndCheck("utf-8; q=0.5, utf-16; q=0.75",
                 this.charsetHeaderValue("utf-16", "q", 0.75f),
                 this.charsetHeaderValue("utf-8", "q", 0.5f));
     }
@@ -434,38 +434,38 @@ public final class AcceptCharsetHeaderValueParserTest extends HeaderValueParserW
     // helpers...................................................................................................
 
     @Override
-    public AcceptCharset parse(final String text) {
+    public AcceptCharset parseString(final String text) {
         return AcceptCharsetHeaderValueParser.parseAcceptCharset(text);
     }
 
-    private void parseAndCheck(final String headerValue, final String charset) {
-        this.parseAndCheck(headerValue, charset, CharsetHeaderValue.NO_PARAMETERS);
+    private void parseStringAndCheck(final String headerValue, final String charset) {
+        this.parseStringAndCheck(headerValue, charset, CharsetHeaderValue.NO_PARAMETERS);
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String charset,
                                final String parameterName, final Object parameterValue) {
-        this.parseAndCheck(headerValue, charset, this.parameters(parameterName, parameterValue));
+        this.parseStringAndCheck(headerValue, charset, this.parameters(parameterName, parameterValue));
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String charset,
                                final String parameterName1, final Object parameterValue1,
                                final String parameterName2, final Object parameterValue2) {
-        this.parseAndCheck(headerValue,
+        this.parseStringAndCheck(headerValue,
                 charset,
                 parameters(parameterName1, parameterValue1, parameterName2, parameterValue2));
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String charset,
                                final Map<CharsetHeaderValueParameterName<?>, Object> parameters) {
-        this.parseAndCheck(headerValue,
+        this.parseStringAndCheck(headerValue,
                 CharsetHeaderValue.with(CharsetName.with(charset)).setParameters(parameters));
     }
 
-    private void parseAndCheck(final String headerValue, final CharsetHeaderValue... values) {
-        this.parseAndCheck(headerValue, AcceptCharset.with(Lists.of(values)));
+    private void parseStringAndCheck(final String headerValue, final CharsetHeaderValue... values) {
+        this.parseStringAndCheck(headerValue, AcceptCharset.with(Lists.of(values)));
     }
 
     private CharsetHeaderValue charsetHeaderValue(final String charset) {

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetTest.java
@@ -66,7 +66,7 @@ public final class AcceptCharsetTest extends HeaderValue2TestCase<AcceptCharset,
 
     @Test
     public void testParse() {
-        this.parseAndCheck("UTF-8;bcd=123 ",
+        this.parseStringAndCheck("UTF-8;bcd=123 ",
                 AcceptCharset.with(Lists.of(CharsetHeaderValue.with(CharsetName.UTF_8).setParameters(Maps.of(CharsetHeaderValueParameterName.with("bcd"), "123")))));
     }
 
@@ -116,7 +116,7 @@ public final class AcceptCharsetTest extends HeaderValue2TestCase<AcceptCharset,
     // ParseStringTesting ........................................................................................
 
     @Override
-    public AcceptCharset parse(final String text) {
+    public AcceptCharset parseString(final String text) {
         return AcceptCharset.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderValueHandlerTest.java
@@ -28,19 +28,19 @@ public final class AcceptEncodingHeaderValueHandlerTest extends NonStringHeaderV
 
     @Test
     public void testParseToken() {
-        this.parseAndCheck2("gzip",
+        this.parseStringAndCheck2("gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testParseTokenToken() {
-        this.parseAndCheck2("gzip; q=0.5, *",
+        this.parseStringAndCheck2("gzip; q=0.5, *",
                 EncodingWithParameters.WILDCARD_ENCODING,
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)));
     }
 
-    private void parseAndCheck2(final String text, final EncodingWithParameters... encodings) {
-        this.parseAndCheck(text, AcceptEncoding.with(Lists.of(encodings)));
+    private void parseStringAndCheck2(final String text, final EncodingWithParameters... encodings) {
+        this.parseStringAndCheck(text, AcceptEncoding.with(Lists.of(encodings)));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderValueParserTest.java
@@ -25,101 +25,101 @@ public final class AcceptEncodingHeaderValueParserTest extends HeaderValueParser
 
     @Test
     public void testWhitespaceFails() {
-        this.parseMissingValueFails("  ");
+        this.parseStringMissingValueFails("  ");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("ab/c", '/');
+        this.parseStringInvalidCharacterFails("ab/c", '/');
     }
 
     @Test
     public void testCommentFails() {
-        this.parseCommentFails("(abc)", 0);
+        this.parseStringCommentFails("(abc)", 0);
     }
 
     @Test
     public void testTokenCommentFails() {
-        this.parseCommentFails("gzip(abc)", 4);
+        this.parseStringCommentFails("gzip(abc)", 4);
     }
 
     @Test
     public void testQuotedTextFails() {
-        this.parseInvalidCharacterFails("\"quoted text 123\"", 0);
+        this.parseStringInvalidCharacterFails("\"quoted text 123\"", 0);
     }
 
     @Test
     public void testTokenQuotedTextFails() {
-        this.parseInvalidCharacterFails("abc \"quoted text 123\"", '"');
+        this.parseStringInvalidCharacterFails("abc \"quoted text 123\"", '"');
     }
 
     @Test
     public void testToken() {
-        this.parseAndCheck2("gzip",
+        this.parseStringAndCheck2("gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testTokenWhitespace() {
-        this.parseAndCheck2("gzip ",
+        this.parseStringAndCheck2("gzip ",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testWhitespaceToken() {
-        this.parseAndCheck2(" gzip",
+        this.parseStringAndCheck2(" gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testTokenParameter() {
-        this.parseAndCheck2("gzip;q=0.5",
+        this.parseStringAndCheck2("gzip;q=0.5",
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)));
     }
 
     @Test
     public void testTokenParameterSemiParameter() {
-        this.parseAndCheck2("gzip;q=0.5;abc=xyz",
+        this.parseStringAndCheck2("gzip;q=0.5;abc=xyz",
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f,
                         EncodingParameterName.with("abc"), "xyz")));
     }
 
     @Test
     public void testWildcard() {
-        this.parseAndCheck2("*",
+        this.parseStringAndCheck2("*",
                 EncodingWithParameters.WILDCARD_ENCODING);
     }
 
     @Test
     public void testWildcardParameter() {
-        this.parseAndCheck2("*;q=0.5",
+        this.parseStringAndCheck2("*;q=0.5",
                 EncodingWithParameters.WILDCARD_ENCODING.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)));
     }
 
     @Test
     public void testTokenCommaToken() {
-        this.parseAndCheck2("gzip,deflate",
+        this.parseStringAndCheck2("gzip,deflate",
                 EncodingWithParameters.GZIP,
                 EncodingWithParameters.DEFLATE);
     }
 
     @Test
     public void testTokenCommaWildcard() {
-        this.parseAndCheck2("gzip,*",
+        this.parseStringAndCheck2("gzip,*",
                 EncodingWithParameters.GZIP,
                 EncodingWithParameters.WILDCARD_ENCODING);
     }
 
     @Test
     public void testWildcardCommaToken() {
-        this.parseAndCheck2("*,gzip",
+        this.parseStringAndCheck2("*,gzip",
                 EncodingWithParameters.WILDCARD_ENCODING,
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testTokenWhitespaceCommaWhitespaceTokenCommaWhitespaceToken() {
-        this.parseAndCheck2("gzip, deflate,  br",
+        this.parseStringAndCheck2("gzip, deflate,  br",
                 EncodingWithParameters.GZIP,
                 EncodingWithParameters.DEFLATE,
                 EncodingWithParameters.BR);
@@ -127,7 +127,7 @@ public final class AcceptEncodingHeaderValueParserTest extends HeaderValueParser
 
     @Test
     public void testSortedByQFactor() {
-        this.parseAndCheck2("gzip;q=0.8, deflate, br;q=0.9",
+        this.parseStringAndCheck2("gzip;q=0.8, deflate, br;q=0.9",
                 EncodingWithParameters.DEFLATE,
                 EncodingWithParameters.BR.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.9f)),
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.8f)));
@@ -135,18 +135,18 @@ public final class AcceptEncodingHeaderValueParserTest extends HeaderValueParser
 
     @Test
     public void testSortedByQFactor2() {
-        this.parseAndCheck2("gzip;q=0.8, deflate;q=1.0",
+        this.parseStringAndCheck2("gzip;q=0.8, deflate;q=1.0",
                 EncodingWithParameters.DEFLATE.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 1.0f)),
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.8f)));
     }
 
-    private void parseAndCheck2(final String text,
+    private void parseStringAndCheck2(final String text,
                                 final EncodingWithParameters... encodings) {
-        this.parseAndCheck(text, AcceptEncoding.with(Lists.of(encodings)));
+        this.parseStringAndCheck(text, AcceptEncoding.with(Lists.of(encodings)));
     }
 
     @Override
-    public AcceptEncoding parse(final String text) {
+    public AcceptEncoding parseString(final String text) {
         return AcceptEncodingHeaderValueParser.parseAcceptEncoding(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptEncodingTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptEncodingTest.java
@@ -90,7 +90,7 @@ public final class AcceptEncodingTest extends HeaderValue2TestCase<AcceptEncodin
 
     @Test
     public void testParse() {
-        this.parseAndCheck("gzip, *;q=0.5",
+        this.parseStringAndCheck("gzip, *;q=0.5",
                 AcceptEncoding.with(Lists.of(EncodingWithParameters.GZIP,
                 EncodingWithParameters.WILDCARD_ENCODING.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)))));
     }
@@ -139,7 +139,7 @@ public final class AcceptEncodingTest extends HeaderValue2TestCase<AcceptEncodin
     // ParseStringTesting ........................................................................................
 
     @Override
-    public AcceptEncoding parse(final String text) {
+    public AcceptEncoding parseString(final String text) {
         return AcceptEncoding.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptLanguageHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptLanguageHeaderValueParserTest.java
@@ -26,14 +26,14 @@ public final class AcceptLanguageHeaderValueParserTest extends AcceptLanguageOrL
 
     @Test
     public void testMultipleLanguages() {
-        this.parseAndCheck3("en-US,en;q=0.5",
+        this.parseStringAndCheck3("en-US,en;q=0.5",
                 this.language("en-US"),
                 this.language("en", 0.5f));
     }
 
     @Test
     public void testMultipleLanguagesSorted() {
-        this.parseAndCheck3("de;q=0.75,fr;q=0.25,en;q=0.5",
+        this.parseStringAndCheck3("de;q=0.75,fr;q=0.25,en;q=0.5",
                 this.language("de", 0.75f),
                 this.language("en", 0.5f),
                 this.language("fr", 0.25f));
@@ -48,18 +48,18 @@ public final class AcceptLanguageHeaderValueParserTest extends AcceptLanguageOrL
         return LanguageWithParameters.with(LanguageName.with(language));
     }
 
-    private void parseAndCheck3(final String text,
+    private void parseStringAndCheck3(final String text,
                                 final LanguageWithParameters... languages) {
-        this.parseAndCheck(text, AcceptLanguage.with(Lists.of(languages)));
+        this.parseStringAndCheck(text, AcceptLanguage.with(Lists.of(languages)));
     }
 
     @Override
-    void parseAndCheck2(final String text, final LanguageWithParameters language) {
-        this.parseAndCheck3(text, language);
+    void parseStringAndCheck2(final String text, final LanguageWithParameters language) {
+        this.parseStringAndCheck3(text, language);
     }
 
     @Override
-    public AcceptLanguage parse(final String text) {
+    public AcceptLanguage parseString(final String text) {
         return AcceptLanguageHeaderValueParser.parseAcceptLanguage(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptLanguageOrLanguageHeaderValueParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/AcceptLanguageOrLanguageHeaderValueParserTestCase.java
@@ -31,38 +31,38 @@ public abstract class AcceptLanguageOrLanguageHeaderValueParserTestCase<P extend
 
     @Test
     public final void testWildcard() {
-        this.parseAndCheck2("*", LanguageWithParameters.WILDCARD);
+        this.parseStringAndCheck2("*", LanguageWithParameters.WILDCARD);
     }
 
     @Test
     public final void testWildcardKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("*;=");
+        this.parseStringInvalidCharacterFails("*;=");
     }
 
     @Test
     public final void testWildcardKeyValueSeparatorFails2() {
-        this.parseInvalidCharacterFails("*; =");
+        this.parseStringInvalidCharacterFails("*; =");
     }
 
     @Test
     public final void testWildcardParameterNameFails() {
-        this.parseMissingParameterValueFails("*; parameter");
+        this.parseStringMissingParameterValueFails("*; parameter");
     }
 
     @Test
     public final void testWildcardParameterNameKeyValueSeparatorFails() {
-        this.parseMissingParameterValueFails("*; parameter=");
+        this.parseStringMissingParameterValueFails("*; parameter=");
     }
 
     @Test
     public final void testWildcardQWeightInvalidValueFails() {
-        this.parseFails("*; q=ABC",
+        this.parseStringFails("*; q=ABC",
                 "Failed to convert \"q\" value \"ABC\", message: For input string: \"ABC\"");
     }
 
     @Test
     public final void testWildcardWithQWeight() {
-        this.parseAndCheck2("*; q=0.75",
+        this.parseStringAndCheck2("*; q=0.75",
                 LanguageWithParameters.WILDCARD.setParameters(Maps.of(LanguageParameterName.Q_FACTOR, 0.75f)));
     }
 
@@ -71,25 +71,25 @@ public abstract class AcceptLanguageOrLanguageHeaderValueParserTestCase<P extend
         final Map<LanguageParameterName<?>, Object> parameters = Maps.of(LanguageParameterName.with("a"), "b",
                 LanguageParameterName.with("c"), "d");
 
-        this.parseAndCheck2("*; a=b; c=d",
+        this.parseStringAndCheck2("*; a=b; c=d",
                 LanguageWithParameters.WILDCARD.setParameters(parameters));
     }
 
     @Test
     public final void testLanguage_en() {
-        this.parseAndCheck2("en", LanguageWithParameters.with(LanguageName.with("en")));
+        this.parseStringAndCheck2("en", LanguageWithParameters.with(LanguageName.with("en")));
     }
 
     @Test
     public final void testLanguage_de_CH() {
-        this.parseAndCheck2("de-CH", LanguageWithParameters.with(LanguageName.with("de-CH")));
+        this.parseStringAndCheck2("de-CH", LanguageWithParameters.with(LanguageName.with("de-CH")));
     }
 
-    abstract void parseAndCheck2(final String text, final LanguageWithParameters expected);
+    abstract void parseStringAndCheck2(final String text, final LanguageWithParameters expected);
 
     @Test
     public final void testQuotedFails() {
-        this.parseFails("\"quoted\"", InvalidCharacterException.class);
+        this.parseStringFails("\"quoted\"", InvalidCharacterException.class);
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/AcceptLanguageTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptLanguageTest.java
@@ -90,7 +90,7 @@ public final class AcceptLanguageTest extends HeaderValue2TestCase<AcceptLanguag
 
     @Test
     public void testParse() {
-        this.parseAndCheck("en, *;q=0.5",
+        this.parseStringAndCheck("en, *;q=0.5",
                 AcceptLanguage.with(Lists.of(LanguageWithParameters.parse("en"),
                 LanguageWithParameters.WILDCARD.setParameters(Maps.of(LanguageParameterName.Q_FACTOR, 0.5f)))));
     }
@@ -147,7 +147,7 @@ public final class AcceptLanguageTest extends HeaderValue2TestCase<AcceptLanguag
     // ParseStringTesting ........................................................................................
 
     @Override
-    public AcceptLanguage parse(final String text) {
+    public AcceptLanguage parseString(final String text) {
         return AcceptLanguage.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/AcceptTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptTest.java
@@ -84,7 +84,7 @@ public final class AcceptTest extends HeaderValue2TestCase<Accept, List<MediaTyp
     // ParseStringTesting ..............................................................................................
 
     @Override
-    public Accept parse(final String text) {
+    public Accept parseString(final String text) {
         return Accept.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderValueHandlerTest.java
@@ -37,12 +37,12 @@ public final class CacheControlDirectiveExtensionHeaderValueHandlerTest extends
 
     @Test
     public void testParseNumber() {
-        this.parseAndCheck("123", 123L);
+        this.parseStringAndCheck("123", 123L);
     }
 
     @Test
     public void testParseText() {
-        this.parseAndCheck("abc", "abc");
+        this.parseStringAndCheck("abc", "abc");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/CacheControlHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlHeaderValueParserTest.java
@@ -28,57 +28,57 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*");
+        this.parseStringInvalidCharacterFails("*");
     }
 
     @Test
     public final void testParameterSeparatorFails() {
-        this.parseInvalidCharacterFails(";");
+        this.parseStringInvalidCharacterFails(";");
     }
 
     @Test
     public final void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testDirective() {
-        this.parseAndCheck2("A", "A");
+        this.parseStringAndCheck2("A", "A");
     }
 
     @Test
     public void testDirectiveParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("A=");
+        this.parseStringMissingParameterValueFails("A=");
     }
 
     @Test
     public void testDirectiveParameterSeparatorWhitespaceFails() {
-        this.parseInvalidCharacterFails("A= ");
+        this.parseStringInvalidCharacterFails("A= ");
     }
 
     @Test
     public void testDirectiveWhitespaceFails() {
-        this.parseInvalidCharacterFails("A ");
+        this.parseStringInvalidCharacterFails("A ");
     }
 
     @Test
     public void testDirectiveValueSeparatorFails() {
-        this.parseInvalidCharacterFails("A,");
+        this.parseStringInvalidCharacterFails("A,");
     }
 
     @Test
     public void testDirectiveValueSeparatorSpaceFails() {
-        this.parseInvalidCharacterFails("A, ");
+        this.parseStringInvalidCharacterFails("A, ");
     }
 
     @Test
@@ -93,427 +93,427 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterNonNumericValueFails() {
-        this.parseInvalidCharacterFails("A=B");
+        this.parseStringInvalidCharacterFails("A=B");
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterNonNumericValueFails2() {
-        this.parseInvalidCharacterFails("A=BCD", 'B');
+        this.parseStringInvalidCharacterFails("A=BCD", 'B');
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterNumericValue() {
-        this.parseAndCheck2("A=1", "A", 1L);
+        this.parseStringAndCheck2("A=1", "A", 1L);
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterNumericValue2() {
-        this.parseAndCheck2("A=123", "A", 123L);
+        this.parseStringAndCheck2("A=123", "A", 123L);
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterQuoteValueQuote() {
-        this.parseAndCheck2("A=\"B\"", "A", "B");
+        this.parseStringAndCheck2("A=\"B\"", "A", "B");
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterQuoteValueQuote2() {
-        this.parseAndCheck2("A=\"BCD\"", "A", "BCD");
+        this.parseStringAndCheck2("A=\"BCD\"", "A", "BCD");
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterQuoteValueQuote3() {
-        this.parseAndCheck2("A=\"1\"", "A", "1");
+        this.parseStringAndCheck2("A=\"1\"", "A", "1");
     }
 
     @Test
     public void testDirectiveKeyValueSeparatorParameterQuoteValueQuoteValueFails() {
         final String text = "A=\"1\"\"2\"";
-        this.parseInvalidCharacterFails(text, text.indexOf('2') - 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('2') - 1);
     }
 
     @Test
     public void testDirectiveCommentKeyValueSeparatorParameterNumericValue() {
-        this.parseAndCheck2("(abc)A=1", "A", 1L);
+        this.parseStringAndCheck2("(abc)A=1", "A", 1L);
     }
 
     // max-age.....................................................
 
     @Test
     public void testMaxAgeWithoutSecondsFails() {
-        this.parseMissingParameterValueFails("max-age");
+        this.parseStringMissingParameterValueFails("max-age");
     }
 
     @Test
     public void testMaxAgeWithoutSecondsSeparatorFails() {
-        this.parseInvalidCharacterFails("max-age,");
+        this.parseStringInvalidCharacterFails("max-age,");
     }
 
     @Test
     public void testMaxAgeWithoutSecondsSpaceSeparatorFails() {
-        this.parseInvalidCharacterFails("max-age ");
+        this.parseStringInvalidCharacterFails("max-age ");
     }
 
     @Test
     public void testMaxAgeWithoutSecondsTabSeparatorFails() {
-        this.parseInvalidCharacterFails("max-age\t");
+        this.parseStringInvalidCharacterFails("max-age\t");
     }
 
     @Test
     public void testMaxAgeInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("max-age=!");
+        this.parseStringInvalidCharacterFails("max-age=!");
     }
 
     @Test
     public void testMaxAgeInvalidCharacterFails2() {
-        this.parseInvalidCharacterFails("max-age=1!");
+        this.parseStringInvalidCharacterFails("max-age=1!");
     }
 
     @Test
     public void testMaxAgeWithSeconds() {
-        this.parseAndCheck2("max-age=1", "max-age", 1L);
+        this.parseStringAndCheck2("max-age=1", "max-age", 1L);
     }
 
     @Test
     public void testMaxAgeWithSeconds2() {
-        this.parseAndCheck2("max-age=23", "max-age", 23L);
+        this.parseStringAndCheck2("max-age=23", "max-age", 23L);
     }
 
     // max-stale.....................................................
 
     @Test
     public void testMaxStaleWithoutSeconds() {
-        this.parseAndCheck2("max-stale", "max-stale");
+        this.parseStringAndCheck2("max-stale", "max-stale");
     }
 
     @Test
     public void testMaxStaleWithoutSecondsSeparatorFails() {
-        this.parseInvalidCharacterFails("max-stale,");
+        this.parseStringInvalidCharacterFails("max-stale,");
     }
 
     @Test
     public void testMaxStaleWithoutSecondsSpace() {
-        this.parseInvalidCharacterFails("max-stale ");
+        this.parseStringInvalidCharacterFails("max-stale ");
     }
 
     @Test
     public void testMaxStaleWithoutSecondsTab() {
-        this.parseInvalidCharacterFails("max-stale\t");
+        this.parseStringInvalidCharacterFails("max-stale\t");
     }
 
     @Test
     public void testMaxStaleInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("max-stale=!");
+        this.parseStringInvalidCharacterFails("max-stale=!");
     }
 
     @Test
     public void testMaxStaleInvalidCharacterFails2() {
-        this.parseInvalidCharacterFails("max-stale=1!");
+        this.parseStringInvalidCharacterFails("max-stale=1!");
     }
 
     @Test
     public void testMaxStaleWithSeconds() {
-        this.parseAndCheck2("max-stale=1", "max-stale", 1L);
+        this.parseStringAndCheck2("max-stale=1", "max-stale", 1L);
     }
 
     @Test
     public void testMaxStaleWithSeconds2() {
-        this.parseAndCheck2("max-stale=23", "max-stale", 23L);
+        this.parseStringAndCheck2("max-stale=23", "max-stale", 23L);
     }
 
     // must-revalidate.....................................................
 
     @Test
     public void testMustRevalidateWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("must-revalidate ");
+        this.parseStringInvalidCharacterFails("must-revalidate ");
     }
 
     @Test
     public void testMustRevalidateWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("must-revalidate\t");
+        this.parseStringInvalidCharacterFails("must-revalidate\t");
     }
 
     @Test
     public void testMustRevalidateParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("must-revalidate=");
+        this.parseStringMissingParameterValueFails("must-revalidate=");
     }
 
     @Test
     public void testMustRevalidateSeparatorFails() {
-        this.parseInvalidCharacterFails("must-revalidate,");
+        this.parseStringInvalidCharacterFails("must-revalidate,");
     }
 
     @Test
     public void testMustRevalidate() {
-        this.parseAndCheck2("must-revalidate", "must-revalidate");
+        this.parseStringAndCheck2("must-revalidate", "must-revalidate");
     }
 
     // no-cache.....................................................
 
     @Test
     public void testNoCacheWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("no-cache ");
+        this.parseStringInvalidCharacterFails("no-cache ");
     }
 
     @Test
     public void testNoCacheWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("no-cache\t");
+        this.parseStringInvalidCharacterFails("no-cache\t");
     }
 
     @Test
     public void testNoCacheParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("no-cache=");
+        this.parseStringMissingParameterValueFails("no-cache=");
     }
 
     @Test
     public void testNoCacheSeparatorFails() {
-        this.parseInvalidCharacterFails("no-cache,");
+        this.parseStringInvalidCharacterFails("no-cache,");
     }
 
     @Test
     public void testNoCache() {
-        this.parseAndCheck2("no-cache", "no-cache");
+        this.parseStringAndCheck2("no-cache", "no-cache");
     }
 
     // no-store.....................................................
 
     @Test
     public void testNoStoreWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("no-store ");
+        this.parseStringInvalidCharacterFails("no-store ");
     }
 
     @Test
     public void testNoStoreWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("no-store\t");
+        this.parseStringInvalidCharacterFails("no-store\t");
     }
 
     @Test
     public void testNoStoreParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("no-store=");
+        this.parseStringMissingParameterValueFails("no-store=");
     }
 
     @Test
     public void testNoStoreSeparatorFails() {
-        this.parseInvalidCharacterFails("no-store,");
+        this.parseStringInvalidCharacterFails("no-store,");
     }
 
     @Test
     public void testNoStore() {
-        this.parseAndCheck2("no-store", "no-store");
+        this.parseStringAndCheck2("no-store", "no-store");
     }
 
     // no-transform.....................................................
 
     @Test
     public void testNoTransformWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("no-transform ");
+        this.parseStringInvalidCharacterFails("no-transform ");
     }
 
     @Test
     public void testNoTransformWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("no-transform\t");
+        this.parseStringInvalidCharacterFails("no-transform\t");
     }
 
     @Test
     public void testNoTransformParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("no-transform=");
+        this.parseStringMissingParameterValueFails("no-transform=");
     }
 
     @Test
     public void testNoTransformSeparatorFails() {
-        this.parseInvalidCharacterFails("no-transform,");
+        this.parseStringInvalidCharacterFails("no-transform,");
     }
 
     @Test
     public void testNoTransform() {
-        this.parseAndCheck2("no-transform", "no-transform");
+        this.parseStringAndCheck2("no-transform", "no-transform");
     }
 
     // public.....................................................
 
     @Test
     public void testPublicWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("public ");
+        this.parseStringInvalidCharacterFails("public ");
     }
 
     @Test
     public void testPublicWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("public\t");
+        this.parseStringInvalidCharacterFails("public\t");
     }
 
     @Test
     public void testPublicParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("public=");
+        this.parseStringMissingParameterValueFails("public=");
     }
 
     @Test
     public void testPublicSeparatorFails() {
-        this.parseInvalidCharacterFails("public,");
+        this.parseStringInvalidCharacterFails("public,");
     }
 
     @Test
     public void testPublic() {
-        this.parseAndCheck2("public", "public");
+        this.parseStringAndCheck2("public", "public");
     }
 
     // private.....................................................
 
     @Test
     public void testPrivateWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("private ");
+        this.parseStringInvalidCharacterFails("private ");
     }
 
     @Test
     public void testPrivateWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("private\t");
+        this.parseStringInvalidCharacterFails("private\t");
     }
 
     @Test
     public void testPrivateParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("private=");
+        this.parseStringMissingParameterValueFails("private=");
     }
 
     @Test
     public void testPrivateSeparatorFails() {
-        this.parseInvalidCharacterFails("private,");
+        this.parseStringInvalidCharacterFails("private,");
     }
 
     @Test
     public void testPrivate() {
-        this.parseAndCheck2("private", "private");
+        this.parseStringAndCheck2("private", "private");
     }
 
     // proxy-revalidate.....................................................
 
     @Test
     public void testProxyRevalidateWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("proxy-revalidate ");
+        this.parseStringInvalidCharacterFails("proxy-revalidate ");
     }
 
     @Test
     public void testProxyRevalidateWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("proxy-revalidate\t");
+        this.parseStringInvalidCharacterFails("proxy-revalidate\t");
     }
 
     @Test
     public void testProxyRevalidateParameterSeparatorFails() {
-        this.parseMissingParameterValueFails("proxy-revalidate=");
+        this.parseStringMissingParameterValueFails("proxy-revalidate=");
     }
 
     @Test
     public void testProxyRevalidateSeparatorFails() {
-        this.parseInvalidCharacterFails("proxy-revalidate,");
+        this.parseStringInvalidCharacterFails("proxy-revalidate,");
     }
 
     @Test
     public void testProxyRevalidate() {
-        this.parseAndCheck2("proxy-revalidate", "proxy-revalidate");
+        this.parseStringAndCheck2("proxy-revalidate", "proxy-revalidate");
     }
 
     // s-maxage.....................................................
 
     @Test
     public void testSmaxAgeWithoutSecondsFails() {
-        this.parseMissingParameterValueFails("s-maxage", 8);
+        this.parseStringMissingParameterValueFails("s-maxage", 8);
     }
 
     @Test
     public void testSmaxAgeWithoutSecondsSeparatorFails() {
-        this.parseInvalidCharacterFails("s-maxage,");
+        this.parseStringInvalidCharacterFails("s-maxage,");
     }
 
     @Test
     public void testSmaxAgeWithoutSecondsSpaceFails() {
-        this.parseInvalidCharacterFails("s-maxage ");
+        this.parseStringInvalidCharacterFails("s-maxage ");
     }
 
     @Test
     public void testSmaxAgeWithoutSecondsTabFails() {
-        this.parseInvalidCharacterFails("s-maxage\t");
+        this.parseStringInvalidCharacterFails("s-maxage\t");
     }
 
     @Test
     public void testSmaxAgeInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("s-maxage=!");
+        this.parseStringInvalidCharacterFails("s-maxage=!");
     }
 
     @Test
     public void testSmaxAgeInvalidCharacterFails2() {
-        this.parseInvalidCharacterFails("s-maxage=1!");
+        this.parseStringInvalidCharacterFails("s-maxage=1!");
     }
 
     @Test
     public void testSmaxAgeWithSeconds() {
-        this.parseAndCheck2("s-maxage=1", "s-maxage", 1L);
+        this.parseStringAndCheck2("s-maxage=1", "s-maxage", 1L);
     }
 
     @Test
     public void testSmaxAgeWithSeconds2() {
-        this.parseAndCheck2("s-maxage=23", "s-maxage", 23L);
+        this.parseStringAndCheck2("s-maxage=23", "s-maxage", 23L);
     }
 
     // custom .....................................................................
 
     @Test
     public void testCustomQuotedValues() {
-        this.parseAndCheck2("custom=\"abc\"",
+        this.parseStringAndCheck2("custom=\"abc\"",
                 "custom",
                 "abc");
     }
 
     @Test
     public void testCustomUnquotedValuesFails() {
-        this.parseInvalidCharacterFails("custom=abc", 'a');
+        this.parseStringInvalidCharacterFails("custom=abc", 'a');
     }
 
     @Test
     public void testImmutable() {
-        this.parseAndCheck2("immutable", "immutable");
+        this.parseStringAndCheck2("immutable", "immutable");
     }
 
     @Test
     public void testStaleWhileRevalidateNumber() {
-        this.parseAndCheck2("stale-while-revalidate=123", "stale-while-revalidate", 123L);
+        this.parseStringAndCheck2("stale-while-revalidate=123", "stale-while-revalidate", 123L);
     }
 
     @Test
     public void testStaleIfError() {
-        this.parseAndCheck2("stale-if-error=456", "stale-if-error", 456L);
+        this.parseStringAndCheck2("stale-if-error=456", "stale-if-error", 456L);
     }
 
     // several ....................................................................
 
     @Test
     public void testMaxAgeSeparatorNoCache() {
-        this.parseAndCheck3("max-age=123,no-cache",
+        this.parseStringAndCheck3("max-age=123,no-cache",
                 CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
                 CacheControlDirective.NO_CACHE);
     }
 
     @Test
     public void testMaxAgeSpaceNoCache() {
-        this.parseAndCheck3("max-age=123, no-cache",
+        this.parseStringAndCheck3("max-age=123, no-cache",
                 CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
                 CacheControlDirective.NO_CACHE);
     }
 
     @Test
     public void testMaxAgeTabNoCache() {
-        this.parseAndCheck3("max-age=123,\tno-cache",
+        this.parseStringAndCheck3("max-age=123,\tno-cache",
                 CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
                 CacheControlDirective.NO_CACHE);
     }
 
     @Test
     public void testMaxAgeSeparatorMaxStale() {
-        this.parseAndCheck3("max-age=123,max-stale=456",
+        this.parseStringAndCheck3("max-age=123,max-stale=456",
                 CacheControlDirectiveName.MAX_AGE.setParameter(Optional.of(123L)),
                 CacheControlDirectiveName.MAX_STALE.setParameter(Optional.of(456L)));
     }
 
     @Test
     public void testNoCacheSeparatorNoStoreSeparatorNoTransform() {
-        this.parseAndCheck3("no-cache,no-store,no-transform",
+        this.parseStringAndCheck3("no-cache,no-store,no-transform",
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE,
                 CacheControlDirective.NO_TRANSFORM);
@@ -521,7 +521,7 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testNoCacheSeparatorSpaceNoStoreSeparatorSpaceNoTransform() {
-        this.parseAndCheck3("no-cache, no-store, no-transform",
+        this.parseStringAndCheck3("no-cache, no-store, no-transform",
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE,
                 CacheControlDirective.NO_TRANSFORM);
@@ -529,7 +529,7 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testNoCacheSeparatorTabNoStoreSeparatorTabNoTransform() {
-        this.parseAndCheck3("no-cache, no-store, no-transform",
+        this.parseStringAndCheck3("no-cache, no-store, no-transform",
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE,
                 CacheControlDirective.NO_TRANSFORM);
@@ -537,7 +537,7 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testNoCacheSeparatorSpaceTabSpaceTabNoStoreSeparatorNoTransform() {
-        this.parseAndCheck3("no-cache, \t \tno-store,no-transform",
+        this.parseStringAndCheck3("no-cache, \t \tno-store,no-transform",
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE,
                 CacheControlDirective.NO_TRANSFORM);
@@ -545,7 +545,7 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testNoCacheSeparatorSpaceCrNlNoStoreSeparatorNoTransform() {
-        this.parseAndCheck3("no-cache,\r\n no-store,no-transform",
+        this.parseStringAndCheck3("no-cache,\r\n no-store,no-transform",
                 CacheControlDirective.NO_CACHE,
                 CacheControlDirective.NO_STORE,
                 CacheControlDirective.NO_TRANSFORM);
@@ -553,33 +553,33 @@ public final class CacheControlHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testExtensionQuotedParameterSeparatorNoTransform() {
-        this.parseAndCheck3("extension=\"abc\",no-transform",
+        this.parseStringAndCheck3("extension=\"abc\",no-transform",
                 CacheControlDirectiveName.with("extension").setParameter(Cast.to(Optional.of("abc"))),
                 CacheControlDirective.NO_TRANSFORM);
     }
 
     // helpers .........................................................................................................
 
-    private void parseAndCheck2(final String text,
+    private void parseStringAndCheck2(final String text,
                                 final String directive) {
-        this.parseAndCheck3(text,
+        this.parseStringAndCheck3(text,
                 CacheControlDirective.with(CacheControlDirectiveName.with(directive), Optional.empty()));
     }
 
-    private void parseAndCheck2(final String text,
+    private void parseStringAndCheck2(final String text,
                                 final String directive,
                                 final Object value) {
-        this.parseAndCheck3(text,
+        this.parseStringAndCheck3(text,
                 CacheControlDirective.with(Cast.to(CacheControlDirectiveName.with(directive)), Optional.of(value)));
     }
 
-    private void parseAndCheck3(final String text,
+    private void parseStringAndCheck3(final String text,
                                 final CacheControlDirective... directives) {
-        this.parseAndCheck(text, CacheControl.with(Lists.of(directives)));
+        this.parseStringAndCheck(text, CacheControl.with(Lists.of(directives)));
     }
 
     @Override
-    public CacheControl parse(final String text) {
+    public CacheControl parseString(final String text) {
         return CacheControlHeaderValueParser.parseCacheControl(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/CacheControlTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlTest.java
@@ -110,7 +110,7 @@ public final class CacheControlTest extends HeaderValueTestCase<CacheControl>
 
     @Test
     public void testParse() {
-        this.parseAndCheck("no-cache, no-store, max-age=123",
+        this.parseStringAndCheck("no-cache, no-store, max-age=123",
                 CacheControl.with(
                         Lists.of(CacheControlDirective.NO_CACHE,
                                 CacheControlDirective.NO_STORE,
@@ -182,7 +182,7 @@ public final class CacheControlTest extends HeaderValueTestCase<CacheControl>
     // ParseStringTesting ..............................................................................................
 
     @Override
-    public CacheControl parse(final String text) {
+    public CacheControl parseString(final String text) {
         return CacheControl.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/CommentRemovingHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/CommentRemovingHeaderValueParserTest.java
@@ -23,7 +23,7 @@ public final class CommentRemovingHeaderValueParserTest extends HeaderValueParse
 
     @Test
     public void testUnterminatedCommentFails() {
-        this.parseFails("(unclosed", "Missing closing ')' in \"(unclosed\"");
+        this.parseStringFails("(unclosed", "Missing closing ')' in \"(unclosed\"");
     }
 
     @Test
@@ -32,130 +32,130 @@ public final class CommentRemovingHeaderValueParserTest extends HeaderValueParse
     }
 
     @Override
-    public void testParseEmptyFails() {
+    public void testParseStringEmptyFails() {
     }
 
     @Test
     public void testEmpty() {
-        this.parseAndCheck("");
+        this.parseStringAndCheck("");
     }
 
     @Test
     public void testSpace() {
-        this.parseAndCheck(" ");
+        this.parseStringAndCheck(" ");
     }
 
     @Test
     public void testLetters() {
-        this.parseAndCheck("abc");
+        this.parseStringAndCheck("abc");
     }
 
     @Test
     public void testDigits() {
-        this.parseAndCheck("123");
+        this.parseStringAndCheck("123");
     }
 
     @Test
     public void testSlash() {
-        this.parseAndCheck("/");
+        this.parseStringAndCheck("/");
     }
 
     @Test
     public void testWildcard() {
-        this.parseAndCheck("*");
+        this.parseStringAndCheck("*");
     }
 
     @Test
     public void testMimeType() {
-        this.parseAndCheck("text/plain");
+        this.parseStringAndCheck("text/plain");
     }
 
     @Test
     public void testMimeTypeStar() {
-        this.parseAndCheck("text/*");
+        this.parseStringAndCheck("text/*");
     }
 
     @Test
     public void testMimeTypeTokenSeparator() {
-        this.parseAndCheck("text/plain;");
+        this.parseStringAndCheck("text/plain;");
     }
 
     @Test
     public void testMimeTypeWithParameters() {
-        this.parseAndCheck("text/plain;q=0.5");
+        this.parseStringAndCheck("text/plain;q=0.5");
     }
 
     @Test
     public void testTokenWithParameters() {
-        this.parseAndCheck("abc;q=0.5");
+        this.parseStringAndCheck("abc;q=0.5");
     }
 
     @Test
     public void testTokenWithManyParameters() {
-        this.parseAndCheck("abc;q=0.5,r=2");
+        this.parseStringAndCheck("abc;q=0.5,r=2");
     }
 
     @Test
     public void testDoubleQuotedText() {
-        this.parseAndCheck("\"abc123\"");
+        this.parseStringAndCheck("\"abc123\"");
     }
 
     @Test
     public void testDoubleQuotedTextWithEscaped() {
-        this.parseAndCheck("\"abc\\t123\"");
+        this.parseStringAndCheck("\"abc\\t123\"");
     }
 
     @Test
     public void testEmptyComment() {
-        this.parseAndCheck("()", "");
+        this.parseStringAndCheck("()", "");
     }
 
     @Test
     public void testComment() {
-        this.parseAndCheck("(comment-a1)", "");
+        this.parseStringAndCheck("(comment-a1)", "");
     }
 
     @Test
     public void testCommentComment() {
-        this.parseAndCheck("(comment-a1)(comment-b2)", "");
+        this.parseStringAndCheck("(comment-a1)(comment-b2)", "");
     }
 
     @Test
     public void testCommentCommentText() {
-        this.parseAndCheck("(comment-a1)(comment-b2)abc", "abc");
+        this.parseStringAndCheck("(comment-a1)(comment-b2)abc", "abc");
     }
 
     @Test
     public void testCommentTextComment() {
-        this.parseAndCheck("(comment-a1)bcd(comment-d2)", "bcd");
+        this.parseStringAndCheck("(comment-a1)bcd(comment-d2)", "bcd");
     }
 
     @Test
     public void testTextCommentTextComment() {
-        this.parseAndCheck("a1(comment-1)b2(comment-2)c3", "a1b2c3");
+        this.parseStringAndCheck("a1(comment-1)b2(comment-2)c3", "a1b2c3");
     }
 
     @Test
     public void testTextCommentDoubleQuotedText() {
-        this.parseAndCheck("a1(comment-1)\"xyz\"", "a1\"xyz\"");
+        this.parseStringAndCheck("a1(comment-1)\"xyz\"", "a1\"xyz\"");
     }
 
     @Test
     public void testTextCommentDoubleQuotedTextTextSingleQuoted() {
-        this.parseAndCheck("a1(comment-1)\"xyz\".'qrs'", "a1\"xyz\".'qrs'");
+        this.parseStringAndCheck("a1(comment-1)\"xyz\".'qrs'", "a1\"xyz\".'qrs'");
     }
 
     @Test
     public void testNoise() {
-        this.parseAndCheck("a*1;/=\"xyz\",q", "a*1;/=\"xyz\",q");
+        this.parseStringAndCheck("a*1;/=\"xyz\",q", "a*1;/=\"xyz\",q");
     }
 
-    private void parseAndCheck(final String text) {
-        this.parseAndCheck(text, text);
+    private void parseStringAndCheck(final String text) {
+        this.parseStringAndCheck(text, text);
     }
 
     @Override
-    public String parse(final String text) {
+    public String parseString(final String text) {
         return CommentRemovingHeaderValueParser.removeComments(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentDispositionHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionHeaderValueParserTest.java
@@ -32,239 +32,239 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*");
+        this.parseStringInvalidCharacterFails("*");
     }
 
     @Test
     public void testParameterSeparatorFails() {
-        this.parseMissingValueFails(";", 0);
+        this.parseStringMissingValueFails(";", 0);
     }
 
     @Test
     public void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testType() {
-        this.parseAndCheck("A", "A");
+        this.parseStringAndCheck("A", "A");
     }
 
     @Test
     public void testTypeSeparatorFails() {
-        this.parseMissingValueFails("A,");
+        this.parseStringMissingValueFails("A,");
     }
 
     @Test
     public void testTypeSeparatorSpaceFails() {
-        this.parseMissingValueFails("A, ");
+        this.parseStringMissingValueFails("A, ");
     }
 
     @Test
     public void testTypeSeparatorTabFails() {
-        this.parseMissingValueFails("A,\t");
+        this.parseStringMissingValueFails("A,\t");
     }
 
     @Test
     public void testTypeInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("A<");
+        this.parseStringInvalidCharacterFails("A<");
     }
 
     @Test
     public void testTypeInvalidCharacterFails2() {
-        this.parseInvalidCharacterFails("ABC<");
+        this.parseStringInvalidCharacterFails("ABC<");
     }
 
     @Test
     public void testTypeEqualsFails() {
-        this.parseMissingParameterValueFails("A;b=");
+        this.parseStringMissingParameterValueFails("A;b=");
     }
 
     @Test
     public void testTypeSpaceEqualsFails() {
-        this.parseMissingParameterValueFails("A;b =");
+        this.parseStringMissingParameterValueFails("A;b =");
     }
 
     @Test
     public void testTypeTabEqualsFails() {
-        this.parseMissingParameterValueFails("A;b =");
+        this.parseStringMissingParameterValueFails("A;b =");
     }
 
     @Test
     public void testTypeSpaceTabSpaceTabEqualsFails() {
-        this.parseMissingParameterValueFails("A;b \t \t=");
+        this.parseStringMissingParameterValueFails("A;b \t \t=");
     }
 
     @Test
     public void testTypeEqualsSpaceFails() {
-        parseMissingParameterValueFails("A;b= ");
+        parseStringMissingParameterValueFails("A;b= ");
     }
 
     @Test
     public void testTypeEqualsTabFails() {
-        parseMissingParameterValueFails("A;b=\t");
+        parseStringMissingParameterValueFails("A;b=\t");
     }
 
     @Test
     public void testTypeEqualsCrNlSpaceFails() {
-        parseMissingParameterValueFails("A;b=\r\n ");
+        parseStringMissingParameterValueFails("A;b=\r\n ");
     }
 
     @Test
     public void testTypeEqualsCrNlTabFails() {
-        parseMissingParameterValueFails("A;b=\r\n\t");
+        parseStringMissingParameterValueFails("A;b=\r\n\t");
     }
 
     @Test
     public void testTypeParameterSeparatorSeparatorFails() {
-        this.parseInvalidCharacterFails("A;;", 2);
+        this.parseStringInvalidCharacterFails("A;;", 2);
     }
 
     @Test
     public void testType2() {
-        this.parseAndCheck("ABC", "ABC");
+        this.parseStringAndCheck("ABC", "ABC");
     }
 
     @Test
     public void testTypeSpace() {
-        this.parseAndCheck("A ", "A");
+        this.parseStringAndCheck("A ", "A");
     }
 
     @Test
     public void testTypeTab() {
-        this.parseAndCheck("A\t", "A");
+        this.parseStringAndCheck("A\t", "A");
     }
 
     @Test
     public void testTypeCrFails() {
-        this.parseInvalidCharacterFails("A\r");
+        this.parseStringInvalidCharacterFails("A\r");
     }
 
     @Test
     public void testTypeCrNlFails() {
-        this.parseInvalidCharacterFails("A\r\n");
+        this.parseStringInvalidCharacterFails("A\r\n");
     }
 
     @Test
     public void testTypeCrNlNonWhitespaceFails() {
-        this.parseInvalidCharacterFails("A\r\n.");
+        this.parseStringInvalidCharacterFails("A\r\n.");
     }
 
     @Test
     public void testTypeCrNlSpace() {
-        this.parseAndCheck("A\r\n ", "A");
+        this.parseStringAndCheck("A\r\n ", "A");
     }
 
     @Test
     public void testTypeCrNlTab() {
-        this.parseAndCheck("A\r\n\t", "A");
+        this.parseStringAndCheck("A\r\n\t", "A");
     }
 
     @Test
     public void testTypeSpaceTabSpaceTab() {
-        this.parseAndCheck("A \t \t", "A");
+        this.parseStringAndCheck("A \t \t", "A");
     }
 
     @Test
     public void testTypeSeparator() {
-        this.parseAndCheck("A;", "A");
+        this.parseStringAndCheck("A;", "A");
     }
 
     @Test
     public void testTypeSeparatorSpace() {
-        this.parseAndCheck("A; ", "A");
+        this.parseStringAndCheck("A; ", "A");
     }
 
     @Test
     public void testTypeSeparatorTab() {
-        this.parseAndCheck("A;\t", "A");
+        this.parseStringAndCheck("A;\t", "A");
     }
 
     @Test
     public void testTypeParameterSeparatorEqualsFails() {
-        this.parseInvalidCharacterFails("A;=");
+        this.parseStringInvalidCharacterFails("A;=");
     }
 
     @Test
     public void testTypeParameterNameInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b>=c", '>');
+        this.parseStringInvalidCharacterFails("A;b>=c", '>');
     }
 
     @Test
     public void testTypeParameterNameSpaceInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b >=c", '>');
+        this.parseStringInvalidCharacterFails("A;b >=c", '>');
     }
 
     @Test
     public void testTypeParameterNameTabInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b\t>=c", '>');
+        this.parseStringInvalidCharacterFails("A;b\t>=c", '>');
     }
 
     @Test
     public void testTypeParameterNameEqualsInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b=\0c", '\0');
+        this.parseStringInvalidCharacterFails("A;b=\0c", '\0');
     }
 
     @Test
     public void testTypeMultiValueSeparatorFails() {
-        this.parseMissingValueFails("A,");
+        this.parseStringMissingValueFails("A,");
     }
 
     @Test
     public void testTypeParameterNameEqualsParameterValue() {
-        this.parseAndCheck("A;b=c",
+        this.parseStringAndCheck("A;b=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameSpaceEqualsParameterValue() {
-        this.parseAndCheck("A;b =c",
+        this.parseStringAndCheck("A;b =c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameTabEqualsParameterValue() {
-        this.parseAndCheck("A;b\t=c",
+        this.parseStringAndCheck("A;b\t=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameSpaceTabSpaceTabEqualsParameterValue() {
-        this.parseAndCheck("A;b \t \t=c",
+        this.parseStringAndCheck("A;b \t \t=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameEqualsSpaceParameterValue() {
-        this.parseAndCheck("A;b= c",
+        this.parseStringAndCheck("A;b= c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameEqualsTabParameterValue() {
-        this.parseAndCheck("A;b=\tc",
+        this.parseStringAndCheck("A;b=\tc",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterNameEqualsSpaceTabSpaceTabParameterValue() {
-        this.parseAndCheck("A;b= \t \tc",
+        this.parseStringAndCheck("A;b= \t \tc",
                 "A",
                 "b", "c");
     }
@@ -272,97 +272,97 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
     @Test
     public void testTypeParameterQuotedParameterValue() {
         final String text = "A;b=c\"d\"";
-        this.parseInvalidCharacterFails(text, text.indexOf('d') - 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('d') - 1);
     }
 
     @Test
     public void testTypeParameterNameEqualsQuotedParameterValue() {
-        this.parseAndCheck("A;b=\"c\"",
+        this.parseStringAndCheck("A;b=\"c\"",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterValueInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b=c>", '>');
+        this.parseStringInvalidCharacterFails("A;b=c>", '>');
     }
 
     @Test
     public void testTypeParameterValueSpaceInvalidCharFails() {
-        this.parseInvalidCharacterFails("A;b=c Q", 'Q');
+        this.parseStringInvalidCharacterFails("A;b=c Q", 'Q');
     }
 
     @Test
     public void testTypeParameterValueSpaceInvalidCharFails2() {
-        this.parseInvalidCharacterFails("A;b=c >", '>');
+        this.parseStringInvalidCharacterFails("A;b=c >", '>');
     }
 
     @Test
     public void testTypeParameterSpace() {
-        this.parseAndCheck("A;bcd=123 ",
+        this.parseStringAndCheck("A;bcd=123 ",
                 "A",
                 "bcd", "123");
     }
 
     @Test
     public void testTypeParameterSeparator() {
-        this.parseAndCheck("A;bcd=123;",
+        this.parseStringAndCheck("A;bcd=123;",
                 "A",
                 "bcd", "123");
     }
 
     @Test
     public void testTypeParameterTab() {
-        this.parseAndCheck("A;bcd=123\t",
+        this.parseStringAndCheck("A;bcd=123\t",
                 "A",
                 "bcd", "123");
     }
 
     @Test
     public void testTypeParameterSpaceTabSpaceTab() {
-        this.parseAndCheck("A;bcd=123 \t \t",
+        this.parseStringAndCheck("A;bcd=123 \t \t",
                 "A",
                 "bcd", "123");
     }
 
     @Test
     public void testTypeParameterSeparatorSpaceParameter() {
-        this.parseAndCheck("A; b=c",
+        this.parseStringAndCheck("A; b=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeParameterSeparatorTabParameter() {
-        this.parseAndCheck("A;\tb=c",
+        this.parseStringAndCheck("A;\tb=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeSpaceParameterSeparatorParameter() {
-        this.parseAndCheck("A ;b=c",
+        this.parseStringAndCheck("A ;b=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeSpaceParameterSeparatorSpaceParameter() {
-        this.parseAndCheck("A ; b=c",
+        this.parseStringAndCheck("A ; b=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeTabParameterSeparatorTabParameter() {
-        this.parseAndCheck("A\t;\tb=c",
+        this.parseStringAndCheck("A\t;\tb=c",
                 "A",
                 "b", "c");
     }
 
     @Test
     public void testTypeSpaceTabSpaceTabParameterSeparatorSpaceTabParameter() {
-        this.parseAndCheck("A \t \t; \t \tb=c",
+        this.parseStringAndCheck("A \t \t; \t \tb=c",
                 "A",
                 "b", "c");
     }
@@ -370,19 +370,19 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
     @Test
     public void testTypeParameterSeparatorParameterNameFails() {
         final String text = "A;b=c;D";
-        this.parseMissingParameterValueFails(text);
+        this.parseStringMissingParameterValueFails(text);
     }
 
     @Test
     public void testTypeParameter() {
-        this.parseAndCheck("V1;p1=v1;",
+        this.parseStringAndCheck("V1;p1=v1;",
                 "V1",
                 "p1", "v1");
     }
 
     @Test
     public void testTypeParameterSeparatorParameter() {
-        this.parseAndCheck("V1;p1=v1;p2=v2",
+        this.parseStringAndCheck("V1;p1=v1;p2=v2",
                 "V1",
                 "p1", "v1",
                 "p2", "v2");
@@ -390,7 +390,7 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testTypeParameterWhitespaceSeparatorParameter() {
-        this.parseAndCheck("V1;p1=v1 ;p2=v2",
+        this.parseStringAndCheck("V1;p1=v1 ;p2=v2",
                 "V1",
                 "p1", "v1",
                 "p2", "v2");
@@ -398,7 +398,7 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testTypeParameterParameterSeparatorWhitespaceParameter() {
-        this.parseAndCheck("V1;p1=v1; p2=v2",
+        this.parseStringAndCheck("V1;p1=v1; p2=v2",
                 "V1",
                 "p1", "v1",
                 "p2", "v2");
@@ -413,13 +413,13 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testCreationDateInvalidFails() {
-        this.parseFails("V; creation-date=123",
+        this.parseStringFails("V; creation-date=123",
                 "Failed to convert \"creation-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
     }
 
     @Test
     public void testCreationDate() {
-        this.parseAndCheck("attachment; creation-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
+        this.parseStringAndCheck("attachment; creation-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
                 "attachment",
                 "creation-date",
                 OffsetDateTime.of(1997, 2, 12, 16, 29, 51, 0, ZoneOffset.ofHours(-5)));
@@ -429,18 +429,18 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testFilenameMissingFails() {
-        this.parseFails("V; filename=\"\"",
+        this.parseStringFails("V; filename=\"\"",
                 "Failed to convert \"filename\" value \"\"\"\", message: name is empty");
     }
 
     @Test
     public void testFilenameMissingFails2() {
-        this.parseMissingParameterValueFails("V; filename=");
+        this.parseStringMissingParameterValueFails("V; filename=");
     }
 
     @Test
     public void testFilename() {
-        this.parseAndCheck("attachment; filename=readme.txt",
+        this.parseStringAndCheck("attachment; filename=readme.txt",
                 "attachment",
                 "filename",
                 ContentDispositionFileName.notEncoded("readme.txt"));
@@ -448,7 +448,7 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testFilenameQuoted() {
-        this.parseAndCheck("attachment; filename=\"readme.txt\"",
+        this.parseStringAndCheck("attachment; filename=\"readme.txt\"",
                 "attachment",
                 "filename",
                 ContentDispositionFileName.notEncoded("readme.txt"));
@@ -458,7 +458,7 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testFilenameStar() {
-        this.parseAndCheck("attachment; filename*=UTF-8'en'abc%20123.txt",
+        this.parseStringAndCheck("attachment; filename*=UTF-8'en'abc%20123.txt",
                 "attachment",
                 "filename*",
                 ContentDispositionFileName.encoded(
@@ -471,13 +471,13 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testModificationDateInvalidFails() {
-        this.parseFails("V; modification-date=123",
+        this.parseStringFails("V; modification-date=123",
                 "Failed to convert \"modification-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
     }
 
     @Test
     public void testModificationDate() {
-        this.parseAndCheck("attachment; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
+        this.parseStringAndCheck("attachment; modification-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
                 "attachment",
                 "modification-date",
                 OffsetDateTime.of(1997, 2, 12, 16, 29, 51, 0, ZoneOffset.ofHours(-5)));
@@ -487,13 +487,13 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testReadDateInvalidFails() {
-        this.parseFails("V; read-date=123",
+        this.parseStringFails("V; read-date=123",
                 "Failed to convert \"read-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
     }
 
     @Test
     public void testReadDate() {
-        this.parseAndCheck("attachment; read-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
+        this.parseStringAndCheck("attachment; read-date=\"Wed, 12 Feb 1997 16:29:51 -0500\"",
                 "attachment",
                 "read-date",
                 OffsetDateTime.of(1997, 2, 12, 16, 29, 51, 0, ZoneOffset.ofHours(-5)));
@@ -503,13 +503,13 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
 
     @Test
     public void testSizeInvalidFails() {
-        this.parseFails("V; size=A",
+        this.parseStringFails("V; size=A",
                 "Failed to convert \"size\" value \"A\", message: For input string: \"A\"");
     }
 
     @Test
     public void testSize() {
-        this.parseAndCheck("attachment; size=123",
+        this.parseStringAndCheck("attachment; size=123",
                 "attachment",
                 "size",
                 123L);
@@ -518,35 +518,35 @@ public final class ContentDispositionHeaderValueParserTest extends HeaderValuePa
     // helpers...................................................................................................
 
     @Override
-    public ContentDisposition parse(final String text) {
+    public ContentDisposition parseString(final String text) {
         return ContentDispositionHeaderValueParser.parseContentDisposition(text);
     }
 
-    private void parseAndCheck(final String headerValue, final String type) {
-        this.parseAndCheck(headerValue, type, ContentDisposition.NO_PARAMETERS);
+    private void parseStringAndCheck(final String headerValue, final String type) {
+        this.parseStringAndCheck(headerValue, type, ContentDisposition.NO_PARAMETERS);
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String type,
                                final String parameterName, final Object parameterValue) {
-        this.parseAndCheck(headerValue, type, Maps.of(ContentDispositionParameterName.with(parameterName), parameterValue));
+        this.parseStringAndCheck(headerValue, type, Maps.of(ContentDispositionParameterName.with(parameterName), parameterValue));
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String type,
                                final String parameterName1, final Object parameterValue1,
                                final String parameterName2, final Object parameterValue2) {
-        this.parseAndCheck(headerValue,
+        this.parseStringAndCheck(headerValue,
                 type,
                 Maps.of(ContentDispositionParameterName.with(parameterName1), parameterValue1,
                         ContentDispositionParameterName.with(parameterName2), parameterValue2));
     }
 
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final String type,
                                final Map<ContentDispositionParameterName<?>, Object> parameters) {
-        this.parseAndCheck(headerValue,
+        this.parseStringAndCheck(headerValue,
                 ContentDispositionType.with(type).setParameters(parameters));
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentDispositionTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionTest.java
@@ -86,7 +86,7 @@ public final class ContentDispositionTest extends HeaderValueWithParametersTestC
 
     @Test
     public void testParse() {
-        this.parseAndCheck("attachment; filename=\"abc.jpg\"",
+        this.parseStringAndCheck("attachment; filename=\"abc.jpg\"",
                 ContentDispositionType.ATTACHMENT.setParameters(Maps.of(ContentDispositionParameterName.FILENAME, ContentDispositionFileName.notEncoded("abc.jpg"))));
     }
 
@@ -243,7 +243,7 @@ public final class ContentDispositionTest extends HeaderValueWithParametersTestC
     // ParseStringTesting ........................................................................................
 
     @Override
-    public ContentDisposition parse(final String text) {
+    public ContentDisposition parseString(final String text) {
         return ContentDisposition.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/ContentEncodingHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentEncodingHeaderValueHandlerTest.java
@@ -27,33 +27,33 @@ public final class ContentEncodingHeaderValueHandlerTest extends NonStringHeader
 
     @Test
     public void testParse() {
-        this.parseAndCheck2("gzip",
+        this.parseStringAndCheck2("gzip",
                 Encoding.GZIP);
     }
 
     @Test
     public void testParse2() {
-        this.parseAndCheck2("GZIP",
+        this.parseStringAndCheck2("GZIP",
                 Encoding.GZIP);
     }
 
     @Test
     public void testParseCommaSeparated() {
-        this.parseAndCheck2("gzip,deflate",
+        this.parseStringAndCheck2("gzip,deflate",
                 Encoding.GZIP,
                 Encoding.DEFLATE);
     }
 
     @Test
     public void testParseWhitespaceCommaSeparated() {
-        this.parseAndCheck2("gzip, deflate,  br",
+        this.parseStringAndCheck2("gzip, deflate,  br",
                 Encoding.GZIP,
                 Encoding.DEFLATE,
                 Encoding.BR);
     }
 
-    private void parseAndCheck2(final String text, final Encoding... encodings) {
-        this.parseAndCheck(text, ContentEncoding.with(Lists.of(encodings)));
+    private void parseStringAndCheck2(final String text, final Encoding... encodings) {
+        this.parseStringAndCheck(text, ContentEncoding.with(Lists.of(encodings)));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentEncodingHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentEncodingHeaderValueParserTest.java
@@ -24,88 +24,88 @@ public final class ContentEncodingHeaderValueParserTest extends HeaderValueParse
 
     @Test
     public void testWhitespaceFails() {
-        this.parseMissingValueFails("  ");
+        this.parseStringMissingValueFails("  ");
     }
 
     @Test
     public void testCommentFails() {
-        this.parseCommentFails("(abc)", 0);
+        this.parseStringCommentFails("(abc)", 0);
     }
 
     @Test
     public void testParametersFails() {
-        this.parseInvalidCharacterFails("gzip;x=1", ';');
+        this.parseStringInvalidCharacterFails("gzip;x=1", ';');
     }
 
     @Test
     public void testQuotedTextFails() {
-        this.parseInvalidCharacterFails("\"hello\"", 0);
+        this.parseStringInvalidCharacterFails("\"hello\"", 0);
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("ab/c", '/');
+        this.parseStringInvalidCharacterFails("ab/c", '/');
     }
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*", '*');
+        this.parseStringInvalidCharacterFails("*", '*');
     }
 
     @Test
     public void testTokenCommaWildcardFails() {
-        this.parseInvalidCharacterFails("abc, *, def", '*');
+        this.parseStringInvalidCharacterFails("abc, *, def", '*');
     }
 
     @Test
     public void testTokenCommentFails() {
-        this.parseCommentFails("gzip(abc)", 4);
+        this.parseStringCommentFails("gzip(abc)", 4);
     }
 
     @Test
     public void testTokenSeparatorFails() {
-        this.parseInvalidCharacterFails("abc;", ';');
+        this.parseStringInvalidCharacterFails("abc;", ';');
     }
 
     @Test
     public void testToken() {
-        this.parseAndCheck2("gzip",
+        this.parseStringAndCheck2("gzip",
                 Encoding.GZIP);
     }
 
     @Test
     public void testTokenWhitespace() {
-        this.parseAndCheck2("gzip ",
+        this.parseStringAndCheck2("gzip ",
                 Encoding.GZIP);
     }
 
     @Test
     public void testWhitespaceToken() {
-        this.parseAndCheck2(" gzip",
+        this.parseStringAndCheck2(" gzip",
                 Encoding.GZIP);
     }
 
     @Test
     public void testTokenCommaToken() {
-        this.parseAndCheck2("gzip,deflate",
+        this.parseStringAndCheck2("gzip,deflate",
                 Encoding.GZIP,
                 Encoding.DEFLATE);
     }
 
     @Test
     public void testTokenWhitespaceCommaWhitespaceTokenCommaWhitespaceToken() {
-        this.parseAndCheck2("gzip, deflate,  br",
+        this.parseStringAndCheck2("gzip, deflate,  br",
                 Encoding.GZIP,
                 Encoding.DEFLATE,
                 Encoding.BR);
     }
 
-    private void parseAndCheck2(final String text, final Encoding...encodings) {
-        this.parseAndCheck(text, ContentEncoding.with(Lists.of(encodings)));
+    private void parseStringAndCheck2(final String text, final Encoding...encodings) {
+        this.parseStringAndCheck(text, ContentEncoding.with(Lists.of(encodings)));
     }
 
     @Override
-    public ContentEncoding parse(final String text) {
+    public ContentEncoding parseString(final String text) {
         return ContentEncodingHeaderValueParser.parseContentEncoding(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentEncodingTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentEncodingTest.java
@@ -76,7 +76,7 @@ public final class ContentEncodingTest extends HeaderValueTestCase<ContentEncodi
 
     @Test
     public void testParse() {
-        this.parseAndCheck("gzip, deflate, br",
+        this.parseStringAndCheck("gzip, deflate, br",
                 this.createHeaderValue(Encoding.parse("gzip"),
                         Encoding.parse("deflate"),
                         Encoding.parse("br")));
@@ -84,7 +84,7 @@ public final class ContentEncodingTest extends HeaderValueTestCase<ContentEncodi
 
     @Test
     public void testParseExtraWhitespace() {
-        this.parseAndCheck("gzip,  deflate,  br",
+        this.parseStringAndCheck("gzip,  deflate,  br",
                 this.createHeaderValue(Encoding.parse("gzip"),
                         Encoding.with("deflate"),
                         Encoding.with("br")));
@@ -161,7 +161,7 @@ public final class ContentEncodingTest extends HeaderValueTestCase<ContentEncodi
     // ParseStringTesting...............................................................................................
 
     @Override
-    public ContentEncoding parse(final String text) {
+    public ContentEncoding parseString(final String text) {
         return ContentEncoding.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/ContentLanguageHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentLanguageHeaderValueHandlerTest.java
@@ -27,7 +27,7 @@ public final class ContentLanguageHeaderValueHandlerTest extends NonStringHeader
 
     @Test
     public void testParse() {
-        this.parseAndCheck("en", ContentLanguage.with(Lists.of(this.en())));
+        this.parseStringAndCheck("en", ContentLanguage.with(Lists.of(this.en())));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentLanguageHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentLanguageHeaderValueParserTest.java
@@ -24,77 +24,77 @@ public final class ContentLanguageHeaderValueParserTest extends HeaderValueParse
 
     @Test
     public void testWhitespaceFails() {
-        this.parseMissingValueFails("  ");
+        this.parseStringMissingValueFails("  ");
     }
 
     @Test
     public void testCommentFails() {
-        this.parseCommentFails("(abc)", 0);
+        this.parseStringCommentFails("(abc)", 0);
     }
 
     @Test
     public void testParametersFails() {
-        this.parseInvalidCharacterFails("en;x=1", ';');
+        this.parseStringInvalidCharacterFails("en;x=1", ';');
     }
 
     @Test
     public void testQuotedTextFails() {
-        this.parseInvalidCharacterFails("\"hello\"", 0);
+        this.parseStringInvalidCharacterFails("\"hello\"", 0);
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("ab/c", '/');
+        this.parseStringInvalidCharacterFails("ab/c", '/');
     }
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*", '*');
+        this.parseStringInvalidCharacterFails("*", '*');
     }
 
     @Test
     public void testTokenCommaWildcardFails() {
-        this.parseInvalidCharacterFails("abc, *, def", '*');
+        this.parseStringInvalidCharacterFails("abc, *, def", '*');
     }
 
     @Test
     public void testTokenCommentFails() {
-        this.parseCommentFails("en(abc)", 2);
+        this.parseStringCommentFails("en(abc)", 2);
     }
 
     @Test
     public void testTokenSeparatorFails() {
-        this.parseInvalidCharacterFails("abc;", ';');
+        this.parseStringInvalidCharacterFails("abc;", ';');
     }
 
     @Test
     public void testToken() {
-        this.parseAndCheck2("en",
+        this.parseStringAndCheck2("en",
                 this.en());
     }
 
     @Test
     public void testTokenWhitespace() {
-        this.parseAndCheck2("en ",
+        this.parseStringAndCheck2("en ",
                 this.en());
     }
 
     @Test
     public void testWhitespaceToken() {
-        this.parseAndCheck2(" en",
+        this.parseStringAndCheck2(" en",
                 this.en());
     }
 
     @Test
     public void testTokenCommaToken() {
-        this.parseAndCheck2("en,fr",
+        this.parseStringAndCheck2("en,fr",
                 this.en(),
                 this.fr());
     }
 
     @Test
     public void testTokenWhitespaceCommaWhitespaceTokenCommaWhitespaceToken() {
-        this.parseAndCheck2("en, fr,  gr",
+        this.parseStringAndCheck2("en, fr,  gr",
                 this.en(),
                 this.fr(),
                 this.gr());
@@ -112,12 +112,12 @@ public final class ContentLanguageHeaderValueParserTest extends HeaderValueParse
         return LanguageName.with("gr");
     }
 
-    private void parseAndCheck2(final String text, final LanguageName...languages) {
-        this.parseAndCheck(text, ContentLanguage.with(Lists.of(languages)));
+    private void parseStringAndCheck2(final String text, final LanguageName...languages) {
+        this.parseStringAndCheck(text, ContentLanguage.with(Lists.of(languages)));
     }
 
     @Override
-    public ContentLanguage parse(final String text) {
+    public ContentLanguage parseString(final String text) {
         return ContentLanguageHeaderValueParser.parseContentLanguage(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentLanguageTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentLanguageTest.java
@@ -57,13 +57,13 @@ public final class ContentLanguageTest extends HeaderValueTestCase<ContentLangua
 
     @Test
     public void testParse() {
-        this.parseAndCheck("en, fr",
+        this.parseStringAndCheck("en, fr",
                 this.createHeaderValue(this.en(), this.fr()));
     }
 
     @Test
     public void testParseExtraWhitespace() {
-        this.parseAndCheck("en,  fr,  gr",
+        this.parseStringAndCheck("en,  fr,  gr",
                 this.createHeaderValue(this.en(), this.fr(), this.gr()));
     }
 
@@ -144,7 +144,7 @@ public final class ContentLanguageTest extends HeaderValueTestCase<ContentLangua
     // ParseStringTesting...............................................................................................
 
     @Override
-    public ContentLanguage parse(final String text) {
+    public ContentLanguage parseString(final String text) {
         return ContentLanguage.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/ContentRangeHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentRangeHeaderValueHandlerTest.java
@@ -34,7 +34,7 @@ public final class ContentRangeHeaderValueHandlerTest extends
 
     @Test
     public void testParseRangeHeader() {
-        this.parseAndCheck(TEXT, this.contentRange());
+        this.parseStringAndCheck(TEXT, this.contentRange());
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentRangeTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentRangeTest.java
@@ -317,17 +317,10 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
                 Optional.of(456L)));
     }
 
-    // parse ......................................................................................................
+    // parseString......................................................................................................
 
     @Test
-    public void testParseNullFails() {
-        assertThrows(NullPointerException.class, () -> {
-            ContentRange.parse(null);
-        });
-    }
-
-    @Test
-    public void testParseEmptyFails() {
+    public void testParseStringEmptyFails() {
         assertThrows(IllegalArgumentException.class, () -> {
             ContentRange.parse("");
         });
@@ -335,62 +328,62 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseUnitUnknownFails() {
-        this.parseFails("b", "Missing unit from \"b\"");
+        this.parseStringFails("b", "Missing unit from \"b\"");
     }
 
     @Test
     public void testParseUnitInvalidFails() {
-        this.parseFails("bytes-0-100/*", '-');
+        this.parseStringFails("bytes-0-100/*", '-');
     }
 
     @Test
     public void testParseUnitLowerBoundInvalidFails() {
-        this.parseFails("bytes 0/", '/');
+        this.parseStringFails("bytes 0/", '/');
     }
 
     @Test
     public void testParseInvalidLowerBoundCharacterFails() {
-        this.parseFails("bytes ?0-100/*", '?');
+        this.parseStringFails("bytes ?0-100/*", '?');
     }
 
     @Test
     public void testParseInvalidLowerBoundCharacterFails2() {
-        this.parseFails("bytes 1?0-100/*", '?');
+        this.parseStringFails("bytes 1?0-100/*", '?');
     }
 
     @Test
     public void testParseMissingRangeSeparatorFails() {
-        this.parseFails("bytes 100?200/*", '?');
+        this.parseStringFails("bytes 100?200/*", '?');
     }
 
     @Test
     public void testParseInvalidUpperBoundCharacterFails() {
-        this.parseFails("bytes 100-?00/*", '?');
+        this.parseStringFails("bytes 100-?00/*", '?');
     }
 
     @Test
     public void testParseInvalidUpperBoundCharacterFails2() {
-        this.parseFails("bytes 100-2?00/*", '?');
+        this.parseStringFails("bytes 100-2?00/*", '?');
     }
 
     @Test
     public void testParseInvalidSizeCharacterFails() {
-        this.parseFails("bytes 100-200/?*", '?');
+        this.parseStringFails("bytes 100-200/?*", '?');
     }
 
     @Test
     public void testParseInvalidSizeCharacterFails2() {
-        this.parseFails("bytes 100-200/1?", '?');
+        this.parseStringFails("bytes 100-200/1?", '?');
     }
 
     @Test
     public void testParseInvalidSizeCharacterFails3() {
-        this.parseFails("bytes 100-200/1*", '*');
+        this.parseStringFails("bytes 100-200/1*", '*');
     }
 
     @Test
     public void testParseMissingRange() {
-        this.parseAndCheck("bytes */*",
+        this.parseStringAndCheck("bytes */*",
                 UNIT,
                 ContentRange.NO_RANGE,
                 ContentRange.NO_SIZE);
@@ -398,7 +391,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseMissingRangeWithFileSize() {
-        this.parseAndCheck("bytes */789",
+        this.parseStringAndCheck("bytes */789",
                 UNIT,
                 ContentRange.NO_RANGE,
                 SIZE);
@@ -406,7 +399,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseSizeMissing() {
-        this.parseAndCheck("bytes 123-456/*",
+        this.parseStringAndCheck("bytes 123-456/*",
                 UNIT,
                 this.range(),
                 ContentRange.NO_SIZE);
@@ -414,7 +407,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseSizePresent() {
-        this.parseAndCheck("bytes 123-456/789",
+        this.parseStringAndCheck("bytes 123-456/789",
                 UNIT,
                 this.range(),
                 SIZE);
@@ -422,7 +415,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseSmallRange() {
-        this.parseAndCheck("bytes 1-2/3",
+        this.parseStringAndCheck("bytes 1-2/3",
                 UNIT,
                 this.range(1, 2),
                 Optional.of(3L));
@@ -430,25 +423,25 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
 
     @Test
     public void testParseTab() {
-        this.parseAndCheck("bytes\t123-456/789",
+        this.parseStringAndCheck("bytes\t123-456/789",
                 UNIT,
                 this.range(),
                 SIZE);
     }
 
-    private void parseFails(final String text, final char invalid) {
-        this.parseFails(text,
+    private void parseStringFails(final String text, final char invalid) {
+        this.parseStringFails(text,
                 new InvalidCharacterException(text, text.indexOf(invalid)).getMessage());
     }
 
-    private void parseFails(final String text, final String message) {
+    private void parseStringFails(final String text, final String message) {
         final HeaderValueException expected = assertThrows(HeaderValueException.class, () -> {
             ContentRange.parse(text);
         });
         checkMessage(expected, message);
     }
 
-    private void parseAndCheck(final String headerValue,
+    private void parseStringAndCheck(final String headerValue,
                                final RangeHeaderValueUnit unit,
                                final Optional<Range<Long>> range,
                                final Optional<Long> size) {
@@ -580,7 +573,7 @@ public final class ContentRangeTest extends HeaderValueTestCase<ContentRange> im
     // ParseStringTesting ........................................................................................
 
     @Override
-    public ContentRange parse(final String text) {
+    public ContentRange parseString(final String text) {
         return ContentRange.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/ETagHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagHeaderValueHandlerTest.java
@@ -29,7 +29,7 @@ public final class ETagHeaderValueHandlerTest extends
 
     @Test
     public void testParse() {
-        this.parseAndCheck("W/\"123\"", ETag.with("123", ETagValidator.WEAK));
+        this.parseStringAndCheck("W/\"123\"", ETag.with("123", ETagValidator.WEAK));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ETagHeaderValueParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/ETagHeaderValueParserTestCase.java
@@ -30,62 +30,62 @@ public abstract class ETagHeaderValueParserTestCase<P extends ETagHeaderValuePar
 
     @Test
     public final void testParameterSeparatorFails() {
-        this.parseInvalidCharacterFails(";");
+        this.parseStringInvalidCharacterFails(";");
     }
 
     @Test
     public final void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public final void testCommentFails() {
-        this.parseCommentFails("(comment-abc123)", 0);
+        this.parseStringCommentFails("(comment-abc123)", 0);
     }
 
     @Test
     public final void testInvalidInitialFails2() {
-        this.parseInvalidCharacterFails("w");
+        this.parseStringInvalidCharacterFails("w");
     }
 
     @Test
     public final void testInvalidInitialFails3() {
-        this.parseInvalidCharacterFails("0");
+        this.parseStringInvalidCharacterFails("0");
     }
 
     @Test
     public final void testInvalidQuotedCharacterFails() {
-        this.parseInvalidCharacterFails("\"abc\0\"", '\0');
+        this.parseStringInvalidCharacterFails("\"abc\0\"", '\0');
     }
 
     @Test
     public final void testInvalidQuotedCharacterFails2() {
-        this.parseInvalidCharacterFails("W/\"abc\0\"", '\0');
+        this.parseStringInvalidCharacterFails("W/\"abc\0\"", '\0');
     }
 
     @Test
     public final void testWFails() {
-        this.parseFails("W", ETagHeaderValueParser.incompleteWeakIndicator("W"));
+        this.parseStringFails("W", ETagHeaderValueParser.incompleteWeakIndicator("W"));
     }
 
     @Test
     public final void testWeaknessWithoutQuotedValueFails() {
-        this.parseMissingValueFails("W/");
+        this.parseStringMissingValueFails("W/");
     }
 
     @Test
     public final void testWeakInvalidFails() {
-        this.parseInvalidCharacterFails("WA");
+        this.parseStringInvalidCharacterFails("WA");
     }
 
     @Test
     public final void testWeakInvalidFails2() {
-        this.parseInvalidCharacterFails("W0");
+        this.parseStringInvalidCharacterFails("W0");
     }
 
     @Test
@@ -105,50 +105,50 @@ public abstract class ETagHeaderValueParserTestCase<P extends ETagHeaderValuePar
 
     @Test
     public final void testWildcard() {
-        this.parseAndCheck("*", ETag.wildcard());
+        this.parseStringAndCheck("*", ETag.wildcard());
     }
 
     @Test
     public final void testValue() {
-        this.parseAndCheck("\"a\"", "a");
+        this.parseStringAndCheck("\"a\"", "a");
     }
 
     @Test
     public final void testValue2() {
-        this.parseAndCheck("\"0\"", "0");
+        this.parseStringAndCheck("\"0\"", "0");
     }
 
     @Test
     public final void testValue3() {
-        this.parseAndCheck("\"0123456789ABCDEF\"", "0123456789ABCDEF");
+        this.parseStringAndCheck("\"0123456789ABCDEF\"", "0123456789ABCDEF");
     }
 
     @Test
     public final void testWeakValue() {
-        this.parseAndCheck("W/\"a\"", "a", ETagValidator.WEAK);
+        this.parseStringAndCheck("W/\"a\"", "a", ETagValidator.WEAK);
     }
 
     @Test
     public final void testWeakValue2() {
-        this.parseAndCheck("W/\"0\"", "0", ETagValidator.WEAK);
+        this.parseStringAndCheck("W/\"0\"", "0", ETagValidator.WEAK);
     }
 
     @Test
     public final void testWeakValue3() {
-        this.parseAndCheck("W/\"0123456789ABCDEF\"", "0123456789ABCDEF", ETagValidator.WEAK);
+        this.parseStringAndCheck("W/\"0123456789ABCDEF\"", "0123456789ABCDEF", ETagValidator.WEAK);
     }
 
     @Test
     public final void testValueCommentFails() {
-        this.parseCommentFails("*(comment-abc123)", 1);
+        this.parseStringCommentFails("*(comment-abc123)", 1);
     }
 
-    final void parseAndCheck(final String text, final String value) {
-        this.parseAndCheck(text, value, ETagValidator.STRONG);
+    final void parseStringAndCheck(final String text, final String value) {
+        this.parseStringAndCheck(text, value, ETagValidator.STRONG);
     }
 
-    final void parseAndCheck(final String text, final String value, final ETagValidator validator) {
-        this.parseAndCheck(text, ETag.with(value, validator));
+    final void parseStringAndCheck(final String text, final String value, final ETagValidator validator) {
+        this.parseStringAndCheck(text, ETag.with(value, validator));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/ETagListHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagListHeaderValueParserTest.java
@@ -29,91 +29,91 @@ public final class ETagListHeaderValueParserTest extends ETagHeaderValueParserTe
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseMissingValueFails(",");
+        this.parseStringMissingValueFails(",");
     }
 
     @Test
     public final void testSeparatorFails() {
-        this.parseMissingValueFails("\"ABC\",");
+        this.parseStringMissingValueFails("\"ABC\",");
     }
 
     @Test
     public final void testSeparatorSpaceFails() {
-        this.parseMissingValueFails("\"ABC\", ");
+        this.parseStringMissingValueFails("\"ABC\", ");
     }
 
     @Test
     public final void testSeparatorTabFails() {
-        this.parseMissingValueFails("\"ABC\",\t");
+        this.parseStringMissingValueFails("\"ABC\",\t");
     }
 
     @Test
     public final void testWeakSeparatorSpaceFails() {
-        this.parseMissingValueFails("W/\"ABC\", ");
+        this.parseStringMissingValueFails("W/\"ABC\", ");
     }
 
     @Test
     public final void testWeakSeparatorTabFails() {
-        this.parseMissingValueFails("W/\"ABC\",\t");
+        this.parseStringMissingValueFails("W/\"ABC\",\t");
     }
 
     @Test
     public void testETagSeparatorETag() {
-        this.parseAndCheck2("\"A\",\"B\"",
+        this.parseStringAndCheck2("\"A\",\"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.STRONG));
     }
 
     @Test
     public void testETagSeparatorSpaceETag() {
-        this.parseAndCheck2("\"A\", \"B\"",
+        this.parseStringAndCheck2("\"A\", \"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.STRONG));
     }
 
     @Test
     public void testETagSeparatorTabETag() {
-        this.parseAndCheck2("\"A\",\t\"B\"",
+        this.parseStringAndCheck2("\"A\",\t\"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.STRONG));
     }
 
     @Test
     public void testETagSeparatorSpaceSpaceETag() {
-        this.parseAndCheck2("\"A\",  \"B\"",
+        this.parseStringAndCheck2("\"A\",  \"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.STRONG));
     }
 
     @Test
     public void testWeakETagSeparatorWeakETag() {
-        this.parseAndCheck2("W/\"A\",W/\"B\"",
+        this.parseStringAndCheck2("W/\"A\",W/\"B\"",
                 ETag.with("A", ETagValidator.WEAK),
                 ETag.with("B", ETagValidator.WEAK));
     }
 
     @Test
     public void testWeakETagSeparatorSpaceWeakETag() {
-        this.parseAndCheck2("\"A\", W/\"B\"",
+        this.parseStringAndCheck2("\"A\", W/\"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.WEAK));
     }
 
     @Test
     public void testWeakETagSeparatorTabWeakETag() {
-        this.parseAndCheck2("\"A\",\tW/\"B\"",
+        this.parseStringAndCheck2("\"A\",\tW/\"B\"",
                 ETag.with("A", ETagValidator.STRONG),
                 ETag.with("B", ETagValidator.WEAK));
     }
 
-    final void parseAndCheck2(final String text, final ETag... tags) {
+    final void parseStringAndCheck2(final String text, final ETag... tags) {
         assertEquals(Lists.of(tags),
                 listReadOnlyCheck(ETagListHeaderValueParser.parseList(text)),
                 "Incorrect result parsing " + CharSequences.quote(text));
     }
 
     @Override
-    public ETag parse(final String text) {
+    public ETag parseString(final String text) {
         final List<ETag> tags = ETagListHeaderValueParser.parseList(text);
         assertEquals(1, tags.size(), "expected one tag =" + CharSequences.quote(text) + "=" + tags);
         return tags.get(0);

--- a/src/test/java/walkingkooka/net/header/ETagOneHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ETagOneHeaderValueParserTest.java
@@ -23,31 +23,31 @@ public final class ETagOneHeaderValueParserTest extends ETagHeaderValueParserTes
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public final void testSeparatorFails() {
-        this.parseInvalidCharacterFails("\"ABC\",", ',');
+        this.parseStringInvalidCharacterFails("\"ABC\",", ',');
     }
 
     @Test
     public final void testSeparatorWhitespaceFails() {
-        this.parseInvalidCharacterFails("\"ABC\", ", ',');
+        this.parseStringInvalidCharacterFails("\"ABC\", ", ',');
     }
 
     @Test
     public final void testWeakSeparatorWhitespaceFails() {
-        this.parseInvalidCharacterFails("W/\"ABC\", ", ',');
+        this.parseStringInvalidCharacterFails("W/\"ABC\", ", ',');
     }
 
     @Test
     public void testManyTags() {
-        this.parseInvalidCharacterFails("\"A\",\"B\"", ',');
+        this.parseStringInvalidCharacterFails("\"A\",\"B\"", ',');
     }
 
     @Override
-    public ETag parse(final String text) {
+    public ETag parseString(final String text) {
         return ETagOneHeaderValueParser.parseOne(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueHandlerHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodedTextHeaderValueHandlerHeaderValueParserTest.java
@@ -28,7 +28,7 @@ public final class EncodedTextHeaderValueHandlerHeaderValueParserTest extends He
 
     @Test
     public void testParse() {
-        this.parseAndCheck("UTF-8''abc%20123", EncodedText.with(CharsetName.UTF_8, EncodedText.NO_LANGUAGE, "abc 123"));
+        this.parseStringAndCheck("UTF-8''abc%20123", EncodedText.with(CharsetName.UTF_8, EncodedText.NO_LANGUAGE, "abc 123"));
     }
 
     @Test
@@ -104,7 +104,7 @@ public final class EncodedTextHeaderValueHandlerHeaderValueParserTest extends He
     }
 
     @Override
-    public EncodedText parse(final String text) {
+    public EncodedText parseString(final String text) {
         return EncodedTextHeaderValueHandlerHeaderValueParser.parseEncodedText(text, LABEL);
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodingHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodingHeaderValueParserTest.java
@@ -23,57 +23,57 @@ public final class EncodingHeaderValueParserTest extends HeaderValueParserTestCa
 
     @Test
     public void testWhitespaceFails() {
-        this.parseInvalidCharacterFails(" ");
+        this.parseStringInvalidCharacterFails(" ");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("ab/c", '/');
+        this.parseStringInvalidCharacterFails("ab/c", '/');
     }
 
     @Test
     public void testCommentFails() {
-        this.parseCommentFails("(abc)", 0);
+        this.parseStringCommentFails("(abc)", 0);
     }
 
     @Test
     public void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=", '=');
+        this.parseStringInvalidCharacterFails("=", '=');
     }
 
     @Test
     public void testTokenCommentFails() {
-        this.parseCommentFails("gzip(abc)", 4);
+        this.parseStringCommentFails("gzip(abc)", 4);
     }
 
     @Test
     public void testQuotedTextFails() {
-        this.parseInvalidCharacterFails("\"quoted text 123\"", 0);
+        this.parseStringInvalidCharacterFails("\"quoted text 123\"", 0);
     }
 
     @Test
     public void testToken() {
-        this.parseAndCheck("gzip",
+        this.parseStringAndCheck("gzip",
                 Encoding.GZIP);
     }
 
     @Test
     public void testTokenParameter() {
-        this.parseInvalidCharacterFails("gzip;q=0.5", ';');
+        this.parseStringInvalidCharacterFails("gzip;q=0.5", ';');
     }
 
     @Test
     public void testWildcard() {
-        this.parseInvalidCharacterFails("*");
+        this.parseStringInvalidCharacterFails("*");
     }
 
     @Test
     public void testTokenCommaToken() {
-        this.parseInvalidCharacterFails("gzip,deflate", ',');
+        this.parseStringInvalidCharacterFails("gzip,deflate", ',');
     }
 
     @Override
-    public Encoding parse(final String text) {
+    public Encoding parseString(final String text) {
         return EncodingHeaderValueParser.parseEncoding(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodingTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodingTest.java
@@ -53,18 +53,18 @@ public final class EncodingTest extends HeaderValueTestCase<Encoding>
 
     @Test
     public void testParse() {
-        this.parseAndCheck("gzip",
+        this.parseStringAndCheck("gzip",
                 Encoding.GZIP);
     }
 
     @Test
     public void testParseExtraWhitespaceFails() {
-        this.parseFails("gzip ", InvalidCharacterException.class);
+        this.parseStringFails("gzip ", InvalidCharacterException.class);
     }
 
     @Test
     public void testParseTokenParametersFails() {
-        this.parseFails("abc;qrs=xyz", InvalidCharacterException.class);
+        this.parseStringFails("abc;qrs=xyz", InvalidCharacterException.class);
     }
 
     @Test
@@ -154,7 +154,7 @@ public final class EncodingTest extends HeaderValueTestCase<Encoding>
     // ParseStringTesting................................................................................................
 
     @Override
-    public Encoding parse(final String text) {
+    public Encoding parseString(final String text) {
         return Encoding.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/EncodingWithParametersHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodingWithParametersHeaderValueParserTest.java
@@ -24,84 +24,84 @@ public final class EncodingWithParametersHeaderValueParserTest extends HeaderVal
 
     @Test
     public void testWhitespaceFails() {
-        this.parseMissingValueFails("  ");
+        this.parseStringMissingValueFails("  ");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("ab/c", '/');
+        this.parseStringInvalidCharacterFails("ab/c", '/');
     }
 
     @Test
     public void testCommentFails() {
-        this.parseCommentFails("(abc)", 0);
+        this.parseStringCommentFails("(abc)", 0);
     }
 
     @Test
     public void testTokenCommentFails() {
-        this.parseCommentFails("gzip(abc)", 4);
+        this.parseStringCommentFails("gzip(abc)", 4);
     }
 
     @Test
     public void testQuotedTextFails() {
-        this.parseInvalidCharacterFails("\"quoted text 123\"", 0);
+        this.parseStringInvalidCharacterFails("\"quoted text 123\"", 0);
     }
 
     @Test
     public void testTokenQuotedTextFails() {
-        this.parseInvalidCharacterFails("abc \"quoted text 123\"", '"');
+        this.parseStringInvalidCharacterFails("abc \"quoted text 123\"", '"');
     }
 
     @Test
     public void testToken() {
-        this.parseAndCheck("gzip",
+        this.parseStringAndCheck("gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testTokenWhitespace() {
-        this.parseAndCheck("gzip ",
+        this.parseStringAndCheck("gzip ",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testWhitespaceToken() {
-        this.parseAndCheck(" gzip",
+        this.parseStringAndCheck(" gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testTokenParameter() {
-        this.parseAndCheck("gzip;q=0.5",
+        this.parseStringAndCheck("gzip;q=0.5",
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)));
     }
 
     @Test
     public void testTokenParameterSemiParameter() {
-        this.parseAndCheck("gzip;q=0.5;abc=xyz",
+        this.parseStringAndCheck("gzip;q=0.5;abc=xyz",
                 EncodingWithParameters.GZIP.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f,
                         EncodingParameterName.with("abc"), "xyz")));
     }
 
     @Test
     public void testWildcard() {
-        this.parseAndCheck("*",
+        this.parseStringAndCheck("*",
                 EncodingWithParameters.WILDCARD_ENCODING);
     }
 
     @Test
     public void testWildcardParameter() {
-        this.parseAndCheck("*;q=0.5",
+        this.parseStringAndCheck("*;q=0.5",
                 EncodingWithParameters.WILDCARD_ENCODING.setParameters(Maps.of(EncodingParameterName.Q_FACTOR, 0.5f)));
     }
 
     @Test
     public void testTokenCommaToken() {
-        this.parseInvalidCharacterFails("gzip,deflate", ',');
+        this.parseStringInvalidCharacterFails("gzip,deflate", ',');
     }
 
     @Override
-    public EncodingWithParameters parse(final String text) {
+    public EncodingWithParameters parseString(final String text) {
         return EncodingWithParametersHeaderValueParser.parseEncoding(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodingWithParametersNonWildcardTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodingWithParametersNonWildcardTest.java
@@ -109,19 +109,19 @@ public final class EncodingWithParametersNonWildcardTest extends EncodingWithPar
 
     @Test
     public void testParse() {
-        this.parseAndCheck("gzip",
+        this.parseStringAndCheck("gzip",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testParseExtraWhitespace() {
-        this.parseAndCheck("gzip ",
+        this.parseStringAndCheck("gzip ",
                 EncodingWithParameters.GZIP);
     }
 
     @Test
     public void testParseTokenParameters() {
-        this.parseAndCheck("abc;qrs=xyz",
+        this.parseStringAndCheck("abc;qrs=xyz",
                 EncodingWithParameters.with("abc").setParameters(Maps.of(EncodingParameterName.with("qrs"), "xyz")));
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodingWithParametersTestCase.java
+++ b/src/test/java/walkingkooka/net/header/EncodingWithParametersTestCase.java
@@ -174,7 +174,7 @@ public abstract class EncodingWithParametersTestCase<A extends EncodingWithParam
     // ParsingStringTest................................................................................................
 
     @Override
-    public EncodingWithParameters parse(final String text) {
+    public EncodingWithParameters parseString(final String text) {
         return EncodingWithParameters.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/EncodingWithParametersWildcardTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodingWithParametersWildcardTest.java
@@ -71,13 +71,13 @@ public final class EncodingWithParametersWildcardTest extends EncodingWithParame
 
     @Test
     public void testParseWildcard() {
-        this.parseAndCheck("*",
+        this.parseStringAndCheck("*",
                 EncodingWithParameters.WILDCARD_ENCODING);
     }
 
     @Test
     public void testParseWhitespaceTokenWhitespace() {
-        this.parseAndCheck(" * ",
+        this.parseStringAndCheck(" * ",
                 EncodingWithParameters.WILDCARD_ENCODING);
     }
 

--- a/src/test/java/walkingkooka/net/header/HeaderValueHandlerTestCase2.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueHandlerTestCase2.java
@@ -114,25 +114,25 @@ public abstract class HeaderValueHandlerTestCase2<C extends HeaderValueHandler<T
     }
 
     final void parseAndToTextAndCheck(final String text, final T value) {
-        this.parseAndCheck(text, value);
+        this.parseStringAndCheck(text, value);
         this.toTextAndCheck(value, text);
     }
 
-    final void parseAndCheck(final String value, final T expected) {
-        this.parseAndCheck(value, this.name(), expected);
+    final void parseStringAndCheck(final String value, final T expected) {
+        this.parseStringAndCheck(value, this.name(), expected);
     }
 
     abstract Name name();
 
-    final void parseAndCheck(final String value, final Name name, final T expected) {
-        this.parseAndCheck(this.handler(), value, name, expected);
+    final void parseStringAndCheck(final String value, final Name name, final T expected) {
+        this.parseStringAndCheck(this.handler(), value, name, expected);
     }
 
-    final void parseAndCheck(final C handler, final String value, final T expected) {
-        this.parseAndCheck(handler, value, this.name(), expected);
+    final void parseStringAndCheck(final C handler, final String value, final T expected) {
+        this.parseStringAndCheck(handler, value, this.name(), expected);
     }
 
-    final void parseAndCheck(final C handler, final String value, final Name name, final T expected) {
+    final void parseStringAndCheck(final C handler, final String value, final Name name, final T expected) {
         assertEquals(expected,
                 handler.parse(value, name),
                 () -> handler + " " + name + " of " + CharSequences.quoteIfChars(value));

--- a/src/test/java/walkingkooka/net/header/HeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueParserTest.java
@@ -291,112 +291,112 @@ public final class HeaderValueParserTest extends HeaderValueParserTestCase<Heade
 
     @Test
     public void testParseSlash() {
-        this.parseAndCheck("/", "[slash]");
+        this.parseStringAndCheck("/", "[slash]");
     }
 
     @Test
     public void testParseWildcard() {
-        this.parseAndCheck("*", "[wildcard]");
+        this.parseStringAndCheck("*", "[wildcard]");
     }
 
     @Test
     public void testParseWildcardWildcard() {
-        this.parseAndCheck("**", "[wildcard][wildcard]");
+        this.parseStringAndCheck("**", "[wildcard][wildcard]");
     }
 
     @Test
     public void testParseToken() {
-        this.parseAndCheck("1", "[token-1]");
+        this.parseStringAndCheck("1", "[token-1]");
     }
 
     @Test
     public void testParseToken2() {
-        this.parseAndCheck("123", "[token-123]");
+        this.parseStringAndCheck("123", "[token-123]");
     }
 
     @Test
     public void testParseTokenWildcardToken() {
-        this.parseAndCheck("123*456", "[token-123][wildcard][token-456]");
+        this.parseStringAndCheck("123*456", "[token-123][wildcard][token-456]");
     }
 
     @Test
     public void testParseTokenSlashToken() {
-        this.parseAndCheck("123/456", "[token-123][slash][token-456]");
+        this.parseStringAndCheck("123/456", "[token-123][slash][token-456]");
     }
 
     @Test
     public void testParseSpaceToken() {
-        this.parseAndCheck(" 1", "[ws][token-1]");
+        this.parseStringAndCheck(" 1", "[ws][token-1]");
     }
 
     @Test
     public void testParseTabToken() {
-        this.parseAndCheck("\t1", "[ws][token-1]");
+        this.parseStringAndCheck("\t1", "[ws][token-1]");
     }
 
     @Test
     public void testParseCrNlSpaceToken() {
-        this.parseAndCheck("\r\n 1", "[ws][token-1]");
+        this.parseStringAndCheck("\r\n 1", "[ws][token-1]");
     }
 
     @Test
     public void testParseCrNlTabToken() {
-        this.parseAndCheck("\r\n 1", "[ws][token-1]");
+        this.parseStringAndCheck("\r\n 1", "[ws][token-1]");
     }
 
     @Test
     public void testParseSpaceTabCrNlSpaceTabToken() {
-        this.parseAndCheck(" \t\r\n \t1", "[ws][token-1]");
+        this.parseStringAndCheck(" \t\r\n \t1", "[ws][token-1]");
     }
 
     @Test
     public void testParseTokenSpace() {
-        this.parseAndCheck("1 ", "[token-1][ws]");
+        this.parseStringAndCheck("1 ", "[token-1][ws]");
     }
 
     @Test
     public void testParseTokenTab() {
-        this.parseAndCheck("1\t", "[token-1][ws]");
+        this.parseStringAndCheck("1\t", "[token-1][ws]");
     }
 
     @Test
     public void testParseTokenCrNlSpace() {
-        this.parseAndCheck("1\r\n ", "[token-1][ws]");
+        this.parseStringAndCheck("1\r\n ", "[token-1][ws]");
     }
 
     @Test
     public void testParseTokenCrNlTab() {
-        this.parseAndCheck("1\r\n\t", "[token-1][ws]");
+        this.parseStringAndCheck("1\r\n\t", "[token-1][ws]");
     }
 
     @Test
     public void testParseTokenTokenSeparator() {
-        this.parseAndCheck("1;", "[token-1][token-separator]");
+        this.parseStringAndCheck("1;", "[token-1][token-separator]");
     }
 
     @Test
     public void testParseTokenTokenSeparatorToken() {
-        this.parseAndCheck("1;23", "[token-1][token-separator][token-23]");
+        this.parseStringAndCheck("1;23", "[token-1][token-separator][token-23]");
     }
 
     @Test
     public void testParseQuotedToken() {
-        this.parseAndCheck("\"1\"", "[quoted-1]");
+        this.parseStringAndCheck("\"1\"", "[quoted-1]");
     }
 
     @Test
     public void testParseQuotedTokenTokenSeparator() {
-        this.parseAndCheck("\"1\",", "[quoted-1][multi]");
+        this.parseStringAndCheck("\"1\",", "[quoted-1][multi]");
     }
 
     @Test
     public void testParseQuotedTokenQuotedToken() {
-        this.parseAndCheck("\"1\"\"23\"", "[quoted-1][quoted-23]");
+        this.parseStringAndCheck("\"1\"\"23\"", "[quoted-1][quoted-23]");
     }
 
     @Test
     public void testParseQuotedTokenSlashWildcardToken() {
-        this.parseAndCheck("\"1\"/*23", "[quoted-1][slash][wildcard][token-23]");
+        this.parseStringAndCheck("\"1\"/*23", "[quoted-1][slash][wildcard][token-23]");
     }
 
     @Test
@@ -424,50 +424,50 @@ public final class HeaderValueParserTest extends HeaderValueParserTestCase<Heade
 
     @Test
     public void testParseCommentWithContent() {
-        this.parseAndCheck("(abc123)", "[comment-abc123]");
+        this.parseStringAndCheck("(abc123)", "[comment-abc123]");
     }
 
     @Test
     public void testParseCommentEmpty() {
-        this.parseAndCheck("()", "[comment-]");
+        this.parseStringAndCheck("()", "[comment-]");
     }
 
     @Test
     public void testParseCommentSingleQuote() {
-        this.parseAndCheck("('abc')", "[comment-'abc']");
+        this.parseStringAndCheck("('abc')", "[comment-'abc']");
     }
 
     @Test
     public void testParseCommentDoubleQuote() {
-        this.parseAndCheck("(\"abc\")", "[comment-\"abc\"]");
+        this.parseStringAndCheck("(\"abc\")", "[comment-\"abc\"]");
     }
 
     @Test
     public void testParseCommentSingleQuoteDoubleQuote() {
-        this.parseAndCheck("('abc'\"def\")", "[comment-'abc'\"def\"]");
+        this.parseStringAndCheck("('abc'\"def\")", "[comment-'abc'\"def\"]");
     }
 
     @Test
     public void testParseCommentComment() {
-        this.parseAndCheck("(abc)(123)", "[comment-abc][comment-123]");
+        this.parseStringAndCheck("(abc)(123)", "[comment-abc][comment-123]");
     }
 
     @Test
     public void testParseTokenComment() {
-        this.parseAndCheck("1(abc)", "[token-1][comment-abc]");
+        this.parseStringAndCheck("1(abc)", "[token-1][comment-abc]");
     }
 
     @Test
     public void testParseTokenTokenSeparatorComment() {
-        this.parseAndCheck("1;(abc)", "[token-1][token-separator][comment-abc]");
+        this.parseStringAndCheck("1;(abc)", "[token-1][token-separator][comment-abc]");
     }
 
     @Test
     public void testParseTokenCommentTokenComment() {
-        this.parseAndCheck("1(abc)2(def)", "[token-1][comment-abc][token-2][comment-def]");
+        this.parseStringAndCheck("1(abc)2(def)", "[token-1][comment-abc][token-2][comment-def]");
     }
 
-    private void parseAndCheck(final String text, final String events) {
+    private void parseStringAndCheck(final String text, final String events) {
         final StringBuilder recorded = new StringBuilder();
 
         new HeaderValueParser(text) {
@@ -541,7 +541,7 @@ public final class HeaderValueParserTest extends HeaderValueParserTestCase<Heade
     // helpers.................................................................................................
 
     @Override
-    public Void parse(final String text) {
+    public Void parseString(final String text) {
         new TestHeaderValueParser(text);
         return null;
     }

--- a/src/test/java/walkingkooka/net/header/HeaderValueParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueParserTestCase.java
@@ -37,57 +37,53 @@ public abstract class HeaderValueParserTestCase<P extends HeaderValueParser, V> 
         super();
     }
 
-    // parse ...........................................................................................
+    // parse ...........................................................................................................
 
-    final void parseCommentFails(final String text, final int pos) {
-        this.parseFails(text,
-                this.parseFailedExpected(new CommentHeaderValueException("Comment present at " + pos + " in " + CharSequences.quoteAndEscape(text))));
+    final void parseStringCommentFails(final String text, final int pos) {
+        this.parseStringFails(text,
+                this.parseStringFailedExpected(new CommentHeaderValueException("Comment present at " + pos + " in " + CharSequences.quoteAndEscape(text))));
     }
 
     final void parseMissingClosingQuoteFails(final String text) {
-        this.parseFails(text, HeaderValueParser.missingClosingQuote(text));
+        this.parseStringFails(text, HeaderValueParser.missingClosingQuote(text));
     }
 
-    final void parseMissingValueFails(final String text) {
-        this.parseMissingValueFails(text, text.length());
+    final void parseStringMissingValueFails(final String text) {
+        this.parseStringMissingValueFails(text, text.length());
     }
 
-    final void parseMissingValueFails(final String text, final int pos) {
-        this.parseFails(text,
+    final void parseStringMissingValueFails(final String text, final int pos) {
+        this.parseStringFails(text,
                 HeaderValueParser.emptyToken(this.valueLabel(), pos, text));
     }
 
     abstract String valueLabel();
 
-    final void parseMissingParameterNameFails(final String text) {
-        this.parseMissingParameterNameFails(text, text.length());
-    }
-
-    final void parseMissingParameterNameFails(final String text, final int pos) {
-        this.parseFails(text,
+    final void parseStringMissingParameterNameFails(final String text, final int pos) {
+        this.parseStringFails(text,
                 HeaderValueParser.missingParameterName(pos, text));
     }
 
-    final void parseMissingParameterValueFails(final String text) {
-        this.parseMissingParameterValueFails(text, text.length());
+    final void parseStringMissingParameterValueFails(final String text) {
+        this.parseStringMissingParameterValueFails(text, text.length());
     }
 
-    final void parseMissingParameterValueFails(final String text, final int pos) {
-        this.parseFails(text,
+    final void parseStringMissingParameterValueFails(final String text, final int pos) {
+        this.parseStringFails(text,
                 HeaderValueParser.missingParameterValue(pos, text));
     }
 
-    final void parseFails(final String text, final String message) {
-        this.parseFails(text, new HeaderValueException(message));
+    final void parseStringFails(final String text, final String message) {
+        this.parseStringFails(text, new HeaderValueException(message));
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return new HeaderValueException(expected.getMessage(), expected);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return HeaderValueException.class;
     }
 

--- a/src/test/java/walkingkooka/net/header/HeaderValueParserWithParametersTest.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueParserWithParametersTest.java
@@ -29,153 +29,153 @@ public final class HeaderValueParserWithParametersTest extends HeaderValueParser
 
     @Test
     public void testParseQuotedFails() {
-        this.parseInvalidCharacterFails("\"quoted\"", '"');
+        this.parseStringInvalidCharacterFails("\"quoted\"", '"');
     }
 
     @Test
     public void testParseParameterSeparatorFails() {
-        this.parseMissingValueFails(";", 0);
+        this.parseStringMissingValueFails(";", 0);
     }
 
     @Test
     public void testParseValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testParseKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testParseValue() {
-        this.parseAndCheck("v", "[value-v]v");
+        this.parseStringAndCheck("v", "[value-v]v");
     }
 
     @Test
     public void testParseWildcard() {
-        this.parseAndCheck("*", "[wildcard]*");
+        this.parseStringAndCheck("*", "[wildcard]*");
     }
 
     @Test
     public void testParseSlash() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testParseValueSpace() {
-        this.parseAndCheck("v ", "[value-v]v");
+        this.parseStringAndCheck("v ", "[value-v]v");
     }
 
     @Test
     public void testParseValueTab() {
-        this.parseAndCheck("v\t", "[value-v]v");
+        this.parseStringAndCheck("v\t", "[value-v]v");
     }
 
     @Test
     public void testParseValueCrNlSpace() {
-        this.parseAndCheck("v\r\n ", "[value-v]v");
+        this.parseStringAndCheck("v\r\n ", "[value-v]v");
     }
 
     @Test
     public void testParseValueCrNlTab() {
-        this.parseAndCheck("v\r\n\t", "[value-v]v");
+        this.parseStringAndCheck("v\r\n\t", "[value-v]v");
     }
 
     @Test
     public void testParseValueCrFails() {
-        this.parseInvalidCharacterFails("v\r");
+        this.parseStringInvalidCharacterFails("v\r");
     }
 
     @Test
     public void testParseValueCrNlFails() {
-        this.parseInvalidCharacterFails("v\r\n");
+        this.parseStringInvalidCharacterFails("v\r\n");
     }
 
     @Test
     public void testParseValueCrNlNonWhitespaceFails() {
-        this.parseInvalidCharacterFails("v\r\n!");
+        this.parseStringInvalidCharacterFails("v\r\n!");
     }
 
     @Test
     public void testParseValueParameterSeparator() {
-        this.parseAndCheck("v;", "[value-v]v");
+        this.parseStringAndCheck("v;", "[value-v]v");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterSeparatorFails() {
-        this.parseInvalidCharacterFails("v;;", 2);
+        this.parseStringInvalidCharacterFails("v;;", 2);
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameFails() {
-        this.parseMissingParameterValueFails("v;p");
+        this.parseStringMissingParameterValueFails("v;p");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("v;p\0");
+        this.parseStringInvalidCharacterFails("v;p\0");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorFails() {
-        this.parseMissingParameterValueFails("v;p=");
+        this.parseStringMissingParameterValueFails("v;p=");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorSpaceFails() {
-        this.parseMissingParameterValueFails("v;p= ");
+        this.parseStringMissingParameterValueFails("v;p= ");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorTabFails() {
-        this.parseMissingParameterValueFails("v;p=\t");
+        this.parseStringMissingParameterValueFails("v;p=\t");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorCrFails() {
-        this.parseInvalidCharacterFails("v;p=\r");
+        this.parseStringInvalidCharacterFails("v;p=\r");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorCrNlFails() {
-        this.parseInvalidCharacterFails("v;p=\r\n");
+        this.parseStringInvalidCharacterFails("v;p=\r\n");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorCrNlNonSpaceFails() {
-        this.parseInvalidCharacterFails("v;p=\r\nq");
+        this.parseStringInvalidCharacterFails("v;p=\r\nq");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorUnquotedParameterValue() {
-        this.parseAndCheck("v;p=u", "[value-v][parameter-name-p][parameter-value-unquoted-u]v; p=u");
+        this.parseStringAndCheck("v;p=u", "[value-v][parameter-name-p][parameter-value-unquoted-u]v; p=u");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorKeyValueSeparatorUnquotedParameterValueFails() {
         final String text = "v;p==u";
-        this.parseInvalidCharacterFails(text, text.indexOf('=') + 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('=') + 1);
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorUnquotedParameterValueParameterSeparator() {
-        this.parseAndCheck("v;p=u;", "[value-v][parameter-name-p][parameter-value-unquoted-u]v; p=u");
+        this.parseStringAndCheck("v;p=u;", "[value-v][parameter-name-p][parameter-value-unquoted-u]v; p=u");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorUnquotedParameterValueValueSeparatorFails() {
-        this.parseInvalidCharacterFails("v;p=u,");
+        this.parseStringInvalidCharacterFails("v;p=u,");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorQuotedParameterValueNonAscii() {
-        this.parseInvalidCharacterFails("v;p=\"\0\"", '\0');
+        this.parseStringInvalidCharacterFails("v;p=\"\0\"", '\0');
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorQuotedParameterValueNonAscii2() {
-        this.parseInvalidCharacterFails("v;p=\"\u0080\"", '\u0080');
+        this.parseStringInvalidCharacterFails("v;p=\"\u0080\"", '\u0080');
     }
 
     @Test
@@ -185,52 +185,52 @@ public final class HeaderValueParserWithParametersTest extends HeaderValueParser
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorQuotedParameterValue() {
-        this.parseAndCheck("v;p=\"q\"", "[value-v][parameter-name-p][parameter-value-quoted-q]v; p=q");
+        this.parseStringAndCheck("v;p=\"q\"", "[value-v][parameter-name-p][parameter-value-quoted-q]v; p=q");
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorQuotedParameterValueQuotedParameterValueFails() {
         final String text = "v;p=\"q\"\"r\"";
-        this.parseInvalidCharacterFails(text, text.indexOf('r') - 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('r') - 1);
     }
 
     @Test
     public void testParseValueParameterSeparatorParameterNameKeyValueSeparatorParameterValueParameterSeparatorParameterNameKeyValueSeparatorParameterValue() {
-        this.parseAndCheck("v;p=\"q\";r=\"s\"",
+        this.parseStringAndCheck("v;p=\"q\";r=\"s\"",
                 "[value-v][parameter-name-p][parameter-value-quoted-q][parameter-name-r][parameter-value-quoted-s]v; p=q; r=s");
     }
 
     @Test
     public void testParseValueValueSeparatorValue() {
-        this.parseAndCheck("v,w",
+        this.parseStringAndCheck("v,w",
                 "[value-v]v[value-w]w");
     }
 
     @Test
     public void testParseValueValueSeparatorValueValueSeparatorValue() {
-        this.parseAndCheck("v,w,x",
+        this.parseStringAndCheck("v,w,x",
                 "[value-v]v[value-w]w[value-x]x");
     }
 
     @Test
     public void testParseValueParametersValueSeparatorValueValueSeparatorValue() {
-        this.parseAndCheck("v;p=q,w,x",
+        this.parseStringAndCheck("v;p=q,w,x",
                 "[value-v][parameter-name-p][parameter-value-unquoted-q]v; p=q[value-w]w[value-x]x");
     }
 
     @Test
     public void testParseWildcardValueSeparatorValue() {
-        this.parseAndCheck("*,v",
+        this.parseStringAndCheck("*,v",
                 "[wildcard]*[value-v]v");
     }
 
     @Test
     public void testParseWildcardValueSeparatorParameterNameKeyValueSeparatorParameterValue() {
-        this.parseAndCheck("*;p=q",
+        this.parseStringAndCheck("*;p=q",
                 "[wildcard][parameter-name-p][parameter-value-unquoted-q]*; p=q");
     }
 
-    private void parseAndCheck(final String text,
+    private void parseStringAndCheck(final String text,
                                final String events) {
         final StringBuilder recorded = new StringBuilder();
 
@@ -293,7 +293,7 @@ public final class HeaderValueParserWithParametersTest extends HeaderValueParser
     }
 
     @Override
-    public Void parse(final String text) {
+    public Void parseString(final String text) {
         new HeaderValueParserWithParameters<CharsetHeaderValue, CharsetHeaderValueParameterName<?>>(text) {
 
             @Override

--- a/src/test/java/walkingkooka/net/header/HeaderValueParserWithParametersTestCase.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueParserWithParametersTestCase.java
@@ -28,6 +28,6 @@ public abstract class HeaderValueParserWithParametersTestCase<P extends HeaderVa
 
     @Test
     public final void testCommentFails() {
-        this.parseCommentFails("(comment-123)", 0);
+        this.parseStringCommentFails("(comment-123)", 0);
     }
 }

--- a/src/test/java/walkingkooka/net/header/HeaderValueTestCase.java
+++ b/src/test/java/walkingkooka/net/header/HeaderValueTestCase.java
@@ -30,12 +30,12 @@ public abstract class HeaderValueTestCase<V extends HeaderValue> implements Clas
     }
 
     @Override
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return new HeaderValueException(expected.getMessage(), expected);
     }
 
     @Override
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return HeaderValueException.class;
     }
 }

--- a/src/test/java/walkingkooka/net/header/HttpHeaderNameListHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpHeaderNameListHeaderValueHandlerTest.java
@@ -34,21 +34,21 @@ public final class HttpHeaderNameListHeaderValueHandlerTest extends
 
     @Test
     public void testParse() {
-        this.parseAndCheck2("Accept", HttpHeaderName.ACCEPT);
+        this.parseStringAndCheck2("Accept", HttpHeaderName.ACCEPT);
     }
 
     @Test
     public void testParse2() {
-        this.parseAndCheck2("Accept,Content-Length", HttpHeaderName.ACCEPT, HttpHeaderName.CONTENT_LENGTH);
+        this.parseStringAndCheck2("Accept,Content-Length", HttpHeaderName.ACCEPT, HttpHeaderName.CONTENT_LENGTH);
     }
 
     @Test
     public void testParseTokenWhitespaceToken() {
-        this.parseAndCheck2("Accept, Content-Length", HttpHeaderName.ACCEPT, HttpHeaderName.CONTENT_LENGTH);
+        this.parseStringAndCheck2("Accept, Content-Length", HttpHeaderName.ACCEPT, HttpHeaderName.CONTENT_LENGTH);
     }
 
-    private void parseAndCheck2(final String value, final HttpHeaderName<?>... headers) {
-        this.parseAndCheck(value, Lists.of(headers));
+    private void parseStringAndCheck2(final String value, final HttpHeaderName<?>... headers) {
+        this.parseStringAndCheck(value, Lists.of(headers));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/HttpMethodListHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpMethodListHeaderValueHandlerTest.java
@@ -35,21 +35,21 @@ public final class HttpMethodListHeaderValueHandlerTest extends
 
     @Test
     public void testParseGet() {
-        this.parseAndCheck2("GET", HttpMethod.GET);
+        this.parseStringAndCheck2("GET", HttpMethod.GET);
     }
 
     @Test
     public void testParseGetPost() {
-        this.parseAndCheck2("GET,POST", HttpMethod.GET, HttpMethod.POST);
+        this.parseStringAndCheck2("GET,POST", HttpMethod.GET, HttpMethod.POST);
     }
 
     @Test
     public void testParseGetWhitespacePost() {
-        this.parseAndCheck2("GET,  POST", HttpMethod.GET, HttpMethod.POST);
+        this.parseStringAndCheck2("GET,  POST", HttpMethod.GET, HttpMethod.POST);
     }
 
-    private void parseAndCheck2(final String headerValue, final HttpMethod... methods) {
-        this.parseAndCheck(headerValue, Lists.of(methods));
+    private void parseStringAndCheck2(final String headerValue, final HttpMethod... methods) {
+        this.parseStringAndCheck(headerValue, Lists.of(methods));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/IfRangeTest.java
+++ b/src/test/java/walkingkooka/net/header/IfRangeTest.java
@@ -43,22 +43,16 @@ public final class IfRangeTest extends HeaderValueTestCase<IfRange<?>> implement
     }
 
     @Test
-    public void testIsWildcard() {
-        this.isWildcardAndCheck(false);
-    }
-
-    @Test
-    public void testParseNullFails() {
-        assertThrows(NullPointerException.class, () -> {
-            IfRange.parse(null);
-        });
-    }
-
-    @Test
-    public void testParseEmptyFails() {
+    @Override
+    public void testParseStringEmptyFails() {
         assertThrows(IllegalArgumentException.class, () -> {
             IfRange.parse("");
         });
+    }
+
+    @Test
+    public void testIsWildcard() {
+        this.isWildcardAndCheck(false);
     }
 
     @Test
@@ -71,21 +65,21 @@ public final class IfRangeTest extends HeaderValueTestCase<IfRange<?>> implement
     @Test
     public void testParseETag() {
         final ETag etag = ETagValidator.WEAK.setValue("abc");
-        this.parseAndCheck(etag.toHeaderText(),
+        this.parseStringAndCheck(etag.toHeaderText(),
                 IfRange.with(etag));
     }
 
     @Test
     public void testParseLastModified() {
         final LocalDateTime lastModified = LocalDateTime.of(2000, 12, 31, 6, 28, 29);
-        this.parseAndCheck(HttpHeaderName.LAST_MODIFIED.headerText(lastModified),
+        this.parseStringAndCheck(HttpHeaderName.LAST_MODIFIED.headerText(lastModified),
                 IfRange.with(lastModified));
     }
 
     // ParseStringTesting ........................................................................................
 
     @Override
-    public IfRange<?> parse(final String text) {
+    public IfRange<?> parseString(final String text) {
         return IfRange.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LanguageWithParametersHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageWithParametersHeaderValueParserTest.java
@@ -23,16 +23,16 @@ public final class LanguageWithParametersHeaderValueParserTest extends AcceptLan
 
     @Test
     public void testLanguageTagValueSeparatorFails() {
-        this.parseInvalidCharacterFails("en,");
+        this.parseStringInvalidCharacterFails("en,");
     }
 
     @Override
-    void parseAndCheck2(final String text, final LanguageWithParameters expected) {
-        this.parseAndCheck(text, expected);
+    void parseStringAndCheck2(final String text, final LanguageWithParameters expected) {
+        this.parseStringAndCheck(text, expected);
     }
 
     @Override
-    public LanguageWithParameters parse(final String text) {
+    public LanguageWithParameters parseString(final String text) {
         return LanguageWithParametersHeaderValueParser.parseLanguage(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LanguageWithParametersTest.java
+++ b/src/test/java/walkingkooka/net/header/LanguageWithParametersTest.java
@@ -140,19 +140,19 @@ public final class LanguageWithParametersTest extends HeaderValueWithParametersT
 
     @Test
     public void testParse() {
-        this.parseAndCheck("en",
+        this.parseStringAndCheck("en",
                 LanguageWithParameters.with(this.en()));
     }
 
     @Test
     public void testParseWithParameters() {
-        this.parseAndCheck("en; abc=123",
+        this.parseStringAndCheck("en; abc=123",
                 LanguageWithParameters.with(this.en())
                         .setParameters(Maps.of(LanguageParameterName.with("abc"), "123")));
     }
 
     @Override
-    public LanguageWithParameters parse(final String text) {
+    public LanguageWithParameters parseString(final String text) {
         return LanguageWithParameters.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LinkHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkHeaderValueParserTest.java
@@ -28,67 +28,67 @@ public final class LinkHeaderValueParserTest extends HeaderValueParserTestCase<L
 
     @Test
     public void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testMultiValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*");
+        this.parseStringInvalidCharacterFails("*");
     }
 
     @Test
     public void testMissingValueFails() {
-        this.parseMissingValueFails("<", 1);
+        this.parseStringMissingValueFails("<", 1);
     }
 
     @Test
     public void testInvalidValueFails() {
-        this.parseInvalidCharacterFails("http://example.com", 0);
+        this.parseStringInvalidCharacterFails("http://example.com", 0);
     }
 
     @Test
     public void testLinkAbsoluteUrl() {
-        this.parseAndCheck2("<http://example.com>",
+        this.parseStringAndCheck2("<http://example.com>",
                 Link.with(Url.parse("http://example.com")));
     }
 
     @Test
     public void testLinkRelativeUrl() {
-        this.parseAndCheck2("</path/file>",
+        this.parseStringAndCheck2("</path/file>",
                 this.link());
     }
 
     @Test
     public void testLinkTypeParameter() {
-        this.parseAndCheck2("</path/file>; type=text/plain",
+        this.parseStringAndCheck2("</path/file>; type=text/plain",
                 this.link(LinkParameterName.TYPE, MediaType.TEXT_PLAIN));
     }
 
     @Test
     public void testLinkRelParameter() {
-        this.parseAndCheck2("</path/file>; rel=prev",
+        this.parseStringAndCheck2("</path/file>; rel=prev",
                 this.link(LinkParameterName.REL, Lists.of(LinkRelation.PREV)));
     }
 
     @Test
     public void testLinkRelParameterUrlValue() {
-        this.parseAndCheck2("</path/file>; rel=http://example.com",
+        this.parseStringAndCheck2("</path/file>; rel=http://example.com",
                 this.link(LinkParameterName.REL, Lists.of(LinkRelation.with("http://example.com"))));
     }
 
     @Test
     public void testLinkRelParameterMultipleValues() {
-        this.parseAndCheck2("</path/file>; rel=\"prev next\"",
+        this.parseStringAndCheck2("</path/file>; rel=\"prev next\"",
                 this.link(LinkParameterName.REL, Lists.of(LinkRelation.PREV, LinkRelation.NEXT)));
     }
 
@@ -100,12 +100,12 @@ public final class LinkHeaderValueParserTest extends HeaderValueParserTestCase<L
         return this.link().setParameters(Maps.of(parameterName, parameterValue));
     }
 
-    private void parseAndCheck2(final String text, final Link... links) {
-        this.parseAndCheck(text, Lists.of(links));
+    private void parseStringAndCheck2(final String text, final Link... links) {
+        this.parseStringAndCheck(text, Lists.of(links));
     }
 
     @Override
-    public List<Link> parse(final String text) {
+    public List<Link> parseString(final String text) {
         return LinkHeaderValueParser.parseLink(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LinkRelationHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkRelationHeaderValueParserTest.java
@@ -26,31 +26,31 @@ public final class LinkRelationHeaderValueParserTest extends HeaderValueParserTe
 
     @Test
     public void testTokenSeparatorFails() {
-        this.parseInvalidCharacterFails(";");
+        this.parseStringInvalidCharacterFails(";");
     }
 
     @Test
     public void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testMultiValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testWildcardFails() {
-        this.parseInvalidCharacterFails("*");
+        this.parseStringInvalidCharacterFails("*");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Override
-    public List<LinkRelation<?>> parse(final String text) {
+    public List<LinkRelation<?>> parseString(final String text) {
         return LinkRelationHeaderValueParser.parseLinkRelationList(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LinkRelationTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkRelationTest.java
@@ -63,7 +63,7 @@ public final class LinkRelationTest extends LinkRelationTestCase<LinkRelation<Ob
 
     @Test
     public void testParse() {
-        this.parseAndCheck("self http://example.com", Lists.of(LinkRelation.SELF, LinkRelation.with("http://example.com")));
+        this.parseStringAndCheck("self http://example.com", Lists.of(LinkRelation.SELF, LinkRelation.with("http://example.com")));
     }
 
     @Override
@@ -98,7 +98,7 @@ public final class LinkRelationTest extends LinkRelationTestCase<LinkRelation<Ob
     // ParseStringTesting ........................................................................................
 
     @Override
-    public List<LinkRelation<?>> parse(final String text) {
+    public List<LinkRelation<?>> parseString(final String text) {
         return LinkRelation.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/LinkTest.java
+++ b/src/test/java/walkingkooka/net/header/LinkTest.java
@@ -263,32 +263,32 @@ public final class LinkTest extends HeaderValueWithParametersTestCase<Link,
 
     @Test
     public void testParseLinkWithMedia() {
-        this.parseAndCheck("<http://example.com>;media=\"abc 123\"",
+        this.parseStringAndCheck("<http://example.com>;media=\"abc 123\"",
                 this.createLink().setParameters(Maps.of(LinkParameterName.MEDIA, "abc 123")));
     }
 
     @Test
     public void testParseLinkWithMethod() {
-        this.parseAndCheck("<http://example.com>;method=GET",
+        this.parseStringAndCheck("<http://example.com>;method=GET",
                 this.createLink().setParameters(Maps.of(LinkParameterName.METHOD, HttpMethod.GET)));
     }
 
     @Test
     public void testParseLinkWithType() {
-        this.parseAndCheck("<http://example.com>;type=text/plain",
+        this.parseStringAndCheck("<http://example.com>;type=text/plain",
                 this.createLink().setParameters(Maps.of(LinkParameterName.TYPE, MediaType.TEXT_PLAIN)));
     }
 
     @Test
     public void testParseSeveralLinks() {
-        this.parseAndCheck("<http://example.com>;rel=previous, <http://example2.com>",
+        this.parseStringAndCheck("<http://example.com>;rel=previous, <http://example2.com>",
                 this.createLink().setParameters(Maps.of(LinkParameterName.REL, LinkRelation.parse("previous"))),
                 Link.with(Url.parse("http://example2.com"))
         );
     }
 
-    private void parseAndCheck(final String text, final Link... links) {
-        this.parseAndCheck(text, Lists.of(links));
+    private void parseStringAndCheck(final String text, final Link... links) {
+        this.parseStringAndCheck(text, Lists.of(links));
     }
 
     // helpers.......................................................................................
@@ -339,7 +339,7 @@ public final class LinkTest extends HeaderValueWithParametersTestCase<Link,
     // ParseStringTesting ........................................................................................
 
     @Override
-    public List<Link> parse(final String text) {
+    public List<Link> parseString(final String text) {
         return Link.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/LocalDateTimeHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/LocalDateTimeHeaderValueHandlerTest.java
@@ -34,7 +34,7 @@ public final class LocalDateTimeHeaderValueHandlerTest extends
 
     @Test
     public void testDate() {
-        this.parseAndCheck(TEXT, VALUE);
+        this.parseStringAndCheck(TEXT, VALUE);
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/MediaTypeBoundaryHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeBoundaryHeaderValueHandlerTest.java
@@ -36,7 +36,7 @@ public final class MediaTypeBoundaryHeaderValueHandlerTest extends
 
     @Test
     public void testParseWithQuotes() {
-        this.parseAndCheck("\"abcdef\"",
+        this.parseStringAndCheck("\"abcdef\"",
                 MediaTypeBoundary.with("abcdef"));
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeBoundaryTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeBoundaryTest.java
@@ -104,12 +104,12 @@ final public class MediaTypeBoundaryTest extends HeaderValueTestCase<MediaTypeBo
 
     @Test
     public void testParseUnquoted() {
-        this.parseAndCheck("abc", MediaTypeBoundary.with("abc"));
+        this.parseStringAndCheck("abc", MediaTypeBoundary.with("abc"));
     }
 
     @Test
     public void testParseQuoted() {
-        this.parseAndCheck("\"abc\"", MediaTypeBoundary.with("abc"));
+        this.parseStringAndCheck("\"abc\"", MediaTypeBoundary.with("abc"));
     }
 
     // toHeaderText........................................................................................................
@@ -283,7 +283,7 @@ final public class MediaTypeBoundaryTest extends HeaderValueTestCase<MediaTypeBo
     // ParseStringTesting ........................................................................................
 
     @Override
-    public MediaTypeBoundary parse(final String text) {
+    public MediaTypeBoundary parseString(final String text) {
         return MediaTypeBoundary.parse(text);
     }
 }

--- a/src/test/java/walkingkooka/net/header/MediaTypeHeaderValueParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeHeaderValueParserTestCase.java
@@ -38,90 +38,90 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testWildcardFails() {
-        this.parseFails("*", "Missing sub type at 1 in \"*\"");
+        this.parseStringFails("*", "Missing sub type at 1 in \"*\"");
     }
 
     @Test
     public final void testKeyValueSeparatorFails() {
-        this.parseInvalidCharacterFails("=");
+        this.parseStringInvalidCharacterFails("=");
     }
 
     @Test
     public void testSlashFails() {
-        this.parseInvalidCharacterFails("/");
+        this.parseStringInvalidCharacterFails("/");
     }
 
     @Test
     public void testValueSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public final void testSlashSubtypeFails() {
-        this.parseInvalidCharacterFails("/subtype", '/');
+        this.parseStringInvalidCharacterFails("/subtype", '/');
     }
 
     @Test
     public final void testTypeFails() {
-        this.parseFails("type",
+        this.parseStringFails("type",
                 "Missing type at 4 in \"type\"");
     }
 
     @Test
     public final void testTypeSlashFails() {
-        this.parseFails("type/",
+        this.parseStringFails("type/",
                 "Missing sub type at 5 in \"type/\"");
     }
 
     @Test
     public final void testTypeInvalidCharacterFails() {
-        this.parseInvalidCharacterFails("prima?ry/subtype",
+        this.parseStringInvalidCharacterFails("prima?ry/subtype",
                 '?');
     }
 
     @Test
     public final void testTypeSlashSubTypeMissingFails() {
-        this.parseInvalidCharacterFails("type/;");
+        this.parseStringInvalidCharacterFails("type/;");
     }
 
     @Test
     public final void testTypeSlashSubTypeSpaceInvalidFails() {
-        this.parseInvalidCharacterFails("type/subtype Q", 'Q');
+        this.parseStringInvalidCharacterFails("type/subtype Q", 'Q');
     }
 
     @Test
     public final void testTypeSlashSubTypeTabInvalidFails() {
-        this.parseInvalidCharacterFails("type/subtype\tQ", 'Q');
+        this.parseStringInvalidCharacterFails("type/subtype\tQ", 'Q');
     }
 
     @Test
     public final void testParameterNameInvalidFails() {
-        this.parseInvalidCharacterFails("type/subtype;parameter;");
+        this.parseStringInvalidCharacterFails("type/subtype;parameter;");
     }
 
     @Test
     public final void testParameterValueInvalidFails() {
-        this.parseInvalidCharacterFails("type/subtype;parameter=value/");
+        this.parseStringInvalidCharacterFails("type/subtype;parameter=value/");
     }
 
     @Test
     public final void testParameterValueMissingFails() {
-        this.parseMissingParameterValueFails("type/subtype;parameter");
+        this.parseStringMissingParameterValueFails("type/subtype;parameter");
     }
 
     @Test
     public final void testParameterValueMissingFails2() {
-        this.parseMissingParameterValueFails("type/subtype;parameter=");
+        this.parseStringMissingParameterValueFails("type/subtype;parameter=");
     }
 
     @Test
     public final void testParameterValueMissingFails3() {
-        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2");
+        this.parseStringMissingParameterValueFails("type/subtype;p1=v1;p2");
     }
 
     @Test
     public final void testParameterValueMissingFails4() {
-        this.parseMissingParameterValueFails("type/subtype;p1=v1;p2=");
+        this.parseStringMissingParameterValueFails("type/subtype;p1=v1;p2=");
     }
 
     @Test
@@ -131,183 +131,183 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testParameterValueQuotedInvalidFails() {
-        this.parseInvalidCharacterFails("type/subtype;p=\"v\";[",
+        this.parseStringInvalidCharacterFails("type/subtype;p=\"v\";[",
                 '[');
     }
 
     @Test
     public final void testParameterValueQuotedInvalidFails2() {
-        this.parseInvalidCharacterFails("type/subtype;p=\"v\"[",
+        this.parseStringInvalidCharacterFails("type/subtype;p=\"v\"[",
                 '[');
     }
 
     @Test
     public void testSeparatorFails() {
-        this.parseInvalidCharacterFails(",");
+        this.parseStringInvalidCharacterFails(",");
     }
 
     @Test
     public void testSeparatorTypeSlashSubtypeFails() {
-        this.parseInvalidCharacterFails(",type/subtype", ',');
+        this.parseStringInvalidCharacterFails(",type/subtype", ',');
     }
 
     @Test
     public final void testTypeSpaceSlashSubFails() {
-        this.parseInvalidCharacterFails("a /b", ' ');
+        this.parseStringInvalidCharacterFails("a /b", ' ');
     }
 
     @Test
     public final void testTypeTabSlashSubFails() {
-        this.parseInvalidCharacterFails("a\t/b", '\t');
+        this.parseStringInvalidCharacterFails("a\t/b", '\t');
     }
 
     @Test
     public final void testTypeSlashSpaceSubFails() {
-        this.parseInvalidCharacterFails("a/ b", ' ');
+        this.parseStringInvalidCharacterFails("a/ b", ' ');
     }
 
     @Test
     public final void testTypeSlashTabSubFails() {
-        this.parseInvalidCharacterFails("a/\tb", '\t');
+        this.parseStringInvalidCharacterFails("a/\tb", '\t');
     }
 
     @Test
     public final void testTypeSlashSubType() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE,
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE,
                 TYPE,
                 SUBTYPE);
     }
 
     @Test
     public final void testTypeWildcardSlashSubType() {
-        this.parseAndCheck("*/*",
+        this.parseStringAndCheck("*/*",
                 MediaType.WILDCARD.string(),
                 MediaType.WILDCARD.string());
     }
 
     @Test
     public final void testTypeSlashSubType2() {
-        this.parseAndCheck("a/b",
+        this.parseStringAndCheck("a/b",
                 "a",
                 "b");
     }
 
     @Test
     public final void testSpaceTypeSlashSub() {
-        this.parseAndCheck(" a/b",
+        this.parseStringAndCheck(" a/b",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTabTypeSlashSub() {
-        this.parseAndCheck("\ta/b",
+        this.parseStringAndCheck("\ta/b",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeWildcard() {
-        this.parseAndCheck("a/*",
+        this.parseStringAndCheck("a/*",
                 "a",
                 MediaType.WILDCARD.string());
     }
 
     @Test
     public final void testTypeSlashSubTypeSpace() {
-        this.parseAndCheck("a/b ",
+        this.parseStringAndCheck("a/b ",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeTab() {
-        this.parseAndCheck("a/b\t",
+        this.parseStringAndCheck("a/b\t",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeCrFails() {
-        this.parseInvalidCharacterFails("a/b\r");
+        this.parseStringInvalidCharacterFails("a/b\r");
     }
 
     @Test
     public final void testTypeSlashSubTypeCrNlFails() {
-        this.parseInvalidCharacterFails("a/b\r\n");
+        this.parseStringInvalidCharacterFails("a/b\r\n");
     }
 
     @Test
     public final void testTypeSlashSubTypeCrNlNonWhitespaceFails() {
-        this.parseInvalidCharacterFails("a/b\r\n!");
+        this.parseStringInvalidCharacterFails("a/b\r\n!");
     }
 
     @Test
     public final void testTypeSlashSubTypeCrNlSpace() {
-        this.parseAndCheck("a/b\r\n ",
+        this.parseStringAndCheck("a/b\r\n ",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeCrNlTab() {
-        this.parseAndCheck("a/b\r\n\t",
+        this.parseStringAndCheck("a/b\r\n\t",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeSpaceSpace() {
-        this.parseAndCheck("a/b  ",
+        this.parseStringAndCheck("a/b  ",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeSpaceTab() {
-        this.parseAndCheck("a/b \t",
+        this.parseStringAndCheck("a/b \t",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeTabTab() {
-        this.parseAndCheck("a/b\t\t",
+        this.parseStringAndCheck("a/b\t\t",
                 "a",
                 "b");
     }
 
     @Test
     public final void testTypeSlashSubTypeTabSpace() {
-        this.parseAndCheck("abc/def\t ",
+        this.parseStringAndCheck("abc/def\t ",
                 "abc",
                 "def");
     }
 
     @Test
     public final void testTypeSlashSubTypePlusSuffix() {
-        this.parseAndCheck("abc/def+suffix",
+        this.parseStringAndCheck("abc/def+suffix",
                 "abc",
                 "def+suffix");
     }
 
     @Test
     public final void testTypeSlashSubTypePrefixSuffix() {
-        this.parseAndCheck("a/b+suffix",
+        this.parseStringAndCheck("a/b+suffix",
                 "a",
                 "b+suffix");
     }
 
     @Test
     public final void testTypeSlashVendorDotSubType() {
-        this.parseAndCheck("a/vnd.b",
+        this.parseStringAndCheck("a/vnd.b",
                 "a",
                 "vnd.b");
     }
 
     @Test
     public final void testTypeSlashSubTypeParameter() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";p=v",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";p=v",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v"));
@@ -315,7 +315,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeParameter2() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -323,7 +323,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeParameterQuotedValue() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -332,12 +332,12 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
     @Test
     public final void testTypeSlashSubTypeParameterParameterValueQuotedParameterValue() {
         final String text = TYPE + "/" + SUBTYPE + ";parameter=\"value\"\"q\"";
-        this.parseInvalidCharacterFails(text, text.indexOf('q') - 1);
+        this.parseStringInvalidCharacterFails(text, text.indexOf('q') - 1);
     }
 
     @Test
     public final void testTypeSlashSubTypeParameterSpace() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value ",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value ",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -345,7 +345,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeParameterTab() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value\t",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value\t",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -353,22 +353,22 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeParameterCrFails() {
-        this.parseInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r");
+        this.parseStringInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r");
     }
 
     @Test
     public final void testTypeSlashSubTypeParameterCrNlFails() {
-        this.parseInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r\n");
+        this.parseStringInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r\n");
     }
 
     @Test
     public final void testTypeSlashSubTypeParameterCrNlNonWhitespaceFails() {
-        this.parseInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r\n!");
+        this.parseStringInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";parameter=value\r\n!");
     }
 
     @Test
     public final void testTypeSlashSubTypeParameterSpaceTabCrNlSpaceTab() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value \t\r\n \t",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value \t\r\n \t",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -376,7 +376,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValue() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -384,7 +384,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueSpace() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" ",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" ",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -392,7 +392,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueTab() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" ",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" ",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -400,7 +400,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueSpaceTabSpaceTab() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" \t \t",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\" \t \t",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "value"));
@@ -408,7 +408,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueOtherwiseInvalidCharacters() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val?ue\"",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val?ue\"",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "val?ue"));
@@ -416,7 +416,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueBackslashEscaped() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\\ue\"",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\\ue\"",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "val\\ue"));
@@ -424,7 +424,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueEscapedDoubleQuote() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\"ue\"",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"val\\\"ue\"",
                 TYPE,
                 SUBTYPE,
                 parameters("parameter", "val\"ue"));
@@ -432,7 +432,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeQuotedParameterValueParameter2() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";p1=\"v1\";p2=v2",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";p1=\"v1\";p2=v2",
                 TYPE,
                 SUBTYPE,
                 parameters("p1", "v1", "p2", "v2"));
@@ -440,7 +440,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeSpaceParameter() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + "; p=v",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + "; p=v",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v"));
@@ -448,7 +448,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeTabParameter() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";\tp=v",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";\tp=v",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v"));
@@ -456,17 +456,17 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeCrParameterFails() {
-        this.parseInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";\rq=v", 'q');
+        this.parseStringInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";\rq=v", 'q');
     }
 
     @Test
     public final void testTypeSlashSubTypeCrNlParameterFails() {
-        this.parseInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";\r\nq=v", 'q');
+        this.parseStringInvalidCharacterFails(TYPE + "/" + SUBTYPE + ";\r\nq=v", 'q');
     }
 
     @Test
     public final void testTypeSlashSubTypeSpaceTabSpaceTabParameter2() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + "; \t \tp=v",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + "; \t \tp=v",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v"));
@@ -474,7 +474,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeParameterParameter() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";p=v;p2=v2",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";p=v;p2=v2",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v", "p2", "v2"));
@@ -482,7 +482,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public final void testTypeSlashSubTypeSpaceTabCrNlSpaceTabParameter() {
-        this.parseAndCheck(TYPE + "/" + SUBTYPE + ";p=v; \t\r\n \tp2=v2",
+        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";p=v; \t\r\n \tp2=v2",
                 TYPE,
                 SUBTYPE,
                 parameters("p", "v", "p2", "v2"));
@@ -490,7 +490,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public void testParameterBoundary() {
-        this.parseAndCheck("type/subtype;boundary=\"abc-123\"",
+        this.parseStringAndCheck("type/subtype;boundary=\"abc-123\"",
                 TYPE,
                 SUBTYPE,
                 parameters("boundary", MediaTypeBoundary.with("abc-123")));
@@ -498,7 +498,7 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
 
     @Test
     public void testParameterCharset() {
-        this.parseAndCheck("type/subtype;charset=utf-8",
+        this.parseStringAndCheck("type/subtype;charset=utf-8",
                 TYPE,
                 SUBTYPE,
                 parameters("charset", CharsetName.UTF_8));
@@ -516,11 +516,11 @@ public abstract class MediaTypeHeaderValueParserTestCase<P extends MediaTypeHead
                 MediaTypeParameterName.with(name2), value2);
     }
 
-    private void parseAndCheck(final String text, final String type, final String subtype) {
+    private void parseStringAndCheck(final String text, final String type, final String subtype) {
         this.check(MediaType.parse(text), type, subtype);
     }
 
-    abstract void parseAndCheck(final String text,
+    abstract void parseStringAndCheck(final String text,
                                 final String type,
                                 final String subtype,
                                 final Map<MediaTypeParameterName<?>, Object> parameters);

--- a/src/test/java/walkingkooka/net/header/MediaTypeListHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeListHeaderValueParserTest.java
@@ -31,84 +31,84 @@ public final class MediaTypeListHeaderValueParserTest extends MediaTypeHeaderVal
 
     @Test
     public void testParameterSeparatorFails() {
-        this.parseMissingValueFails(";", 0);
+        this.parseStringMissingValueFails(";", 0);
     }
 
     @Test
     public void testTypeSlashSubTypeValueSeparatorSeparatorFails() {
-        this.parseMissingValueFails("type/subtype,");
+        this.parseStringMissingValueFails("type/subtype,");
     }
 
     @Test
     public void testTypeSlashSubTypeValueSeparatorWhitespaceFails() {
-        this.parseMissingValueFails("type/subtype, ");
+        this.parseStringMissingValueFails("type/subtype, ");
     }
 
     @Test
     public void testTypeSlashSubParametersValueSeparatorFails() {
-        this.parseMissingValueFails("type/subtype;parameter123=value456,");
+        this.parseStringMissingValueFails("type/subtype;parameter123=value456,");
     }
 
     @Test
     public void testTypeSubTypeWhitespace() {
-        this.parseAndCheck2("type1/subtype1 ",
+        this.parseStringAndCheck2("type1/subtype1 ",
                 MediaType.with("type1", "subtype1"));
     }
 
     @Test
     public void testTypeSubTypeCommaWhitespaceTypeSubType() {
-        this.parseAndCheck2("type1/subtype1, type2/subtype2",
+        this.parseStringAndCheck2("type1/subtype1, type2/subtype2",
                 MediaType.with("type1", "subtype1"),
                 MediaType.with("type2", "subtype2"));
     }
 
     @Test
     public void testTypeSubTypeParameterCommaWhitespaceTypeSubType2() {
-        this.parseAndCheck2("type1/subtype1;p1=v1, type2/subtype2",
+        this.parseStringAndCheck2("type1/subtype1;p1=v1, type2/subtype2",
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("p1", "v1")),
                 MediaType.with("type2", "subtype2"));
     }
 
     @Test
     public void testTypeSubTypeParameterCommaTypeSubTypeParameter() {
-        this.parseAndCheck2("type1/subtype1;p1=v1,type2/subtype2;p2=v2",
+        this.parseStringAndCheck2("type1/subtype1;p1=v1,type2/subtype2;p2=v2",
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("p1", "v1")),
                 MediaType.with("type2", "subtype2").setParameters(this.parameters("p2", "v2")));
     }
 
     @Test
     public void testTypeSubTypeParameterCommaWhitespaceTypeSubTypeParameter() {
-        this.parseAndCheck2("type1/subtype1;p1=v1, type2/subtype2;p2=v2",
+        this.parseStringAndCheck2("type1/subtype1;p1=v1, type2/subtype2;p2=v2",
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("p1", "v1")),
                 MediaType.with("type2", "subtype2").setParameters(this.parameters("p2", "v2")));
     }
 
     @Test
     public void testTypeSubTypeWhitespaceParameterCommaWhitespaceTypeSubTypeWhitespaceParameter() {
-        this.parseAndCheck2("type1/subtype1; p1=v1, type2/subtype2; p2=v2",
+        this.parseStringAndCheck2("type1/subtype1; p1=v1, type2/subtype2; p2=v2",
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("p1", "v1")),
                 MediaType.with("type2", "subtype2").setParameters(this.parameters("p2", "v2")));
     }
 
     @Test
     public void testSortedByQFactor() {
-        this.parseAndCheck2("type1/subtype1; q=0.25, type2/subtype2; q=1.0, type3/subtype3; q=0.5",
+        this.parseStringAndCheck2("type1/subtype1; q=0.25, type2/subtype2; q=1.0, type3/subtype3; q=0.5",
                 MediaType.with("type2", "subtype2").setParameters(this.parameters("q", 1.0f)),
                 MediaType.with("type3", "subtype3").setParameters(this.parameters("q", 0.5f)),
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("q", 0.25f)));
     }
 
     @Override
-    final void parseAndCheck(final String text,
+    final void parseStringAndCheck(final String text,
                              final String type,
                              final String subtype,
                              final Map<MediaTypeParameterName<?>, Object> parameters) {
-        parseAndCheckOne(text, type, subtype, parameters);
-        parseAndCheckRepeated(text, type, subtype, parameters);
-        parseAndCheckSeveral(text, type, subtype, parameters);
+        parseStringAndCheckOne(text, type, subtype, parameters);
+        parseStringAndCheckRepeated(text, type, subtype, parameters);
+        parseStringAndCheckSeveral(text, type, subtype, parameters);
     }
 
-    private void parseAndCheckOne(final String text,
+    private void parseStringAndCheckOne(final String text,
                                   final String type,
                                   final String subtype,
                                   final Map<MediaTypeParameterName<?>, Object> parameters) {
@@ -117,7 +117,7 @@ public final class MediaTypeListHeaderValueParserTest extends MediaTypeHeaderVal
         this.check(result.get(0), type, subtype, parameters);
     }
 
-    private void parseAndCheckRepeated(final String text,
+    private void parseStringAndCheckRepeated(final String text,
                                        final String type,
                                        final String subtype,
                                        final Map<MediaTypeParameterName<?>, Object> parameters) {
@@ -128,7 +128,7 @@ public final class MediaTypeListHeaderValueParserTest extends MediaTypeHeaderVal
         this.check(result.get(1), type, subtype, parameters);
     }
 
-    private void parseAndCheckSeveral(final String text,
+    private void parseStringAndCheckSeveral(final String text,
                                       final String type,
                                       final String subtype,
                                       final Map<MediaTypeParameterName<?>, Object> parameters) {
@@ -144,14 +144,14 @@ public final class MediaTypeListHeaderValueParserTest extends MediaTypeHeaderVal
         this.check(result.get(3), type, subtype, parameters);
     }
 
-    private void parseAndCheck2(final String text, final MediaType... mediaTypes) {
+    private void parseStringAndCheck2(final String text, final MediaType... mediaTypes) {
         assertEquals(Lists.of(mediaTypes),
                 MediaTypeListHeaderValueParser.parseMediaTypeList(text),
                 "Incorrect result parsing " + CharSequences.quote(text));
     }
 
     @Override
-    public List<MediaType> parse(final String text) {
+    public List<MediaType> parseString(final String text) {
         return listReadOnlyCheck(MediaTypeListHeaderValueParser.parseMediaTypeList(text));
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderValueParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderValueParserTest.java
@@ -25,21 +25,21 @@ public final class MediaTypeOneHeaderValueParserTest extends MediaTypeHeaderValu
         MediaType> {
     @Test
     public void testParameterSeparatorFails() {
-        this.parseMissingValueFails(";", 0);
+        this.parseStringMissingValueFails(";", 0);
     }
 
     @Test
     public void testTypeSlashSubTypeValueSeparatorFails() {
-        this.parseInvalidCharacterFails("type/subtype,");
+        this.parseStringInvalidCharacterFails("type/subtype,");
     }
 
     @Test
     public void testTypeSlashSubTypeParameterSeparatorParameterNameKeyValueSeparatorParameterValueValueSeparatorFails() {
-        this.parseInvalidCharacterFails("type/subtype;p=v,");
+        this.parseStringInvalidCharacterFails("type/subtype;p=v,");
     }
 
     @Override
-    final void parseAndCheck(final String text,
+    final void parseStringAndCheck(final String text,
                              final String type,
                              final String subtype,
                              final Map<MediaTypeParameterName<?>, Object> parameters) {
@@ -47,7 +47,7 @@ public final class MediaTypeOneHeaderValueParserTest extends MediaTypeHeaderValu
     }
 
     @Override
-    public MediaType parse(final String text) {
+    public MediaType parseString(final String text) {
         return MediaTypeOneHeaderValueParser.parseMediaType(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -425,34 +425,34 @@ final public class MediaTypeTest extends HeaderValueWithParametersTestCase<Media
 
     @Test
     public void testParse() {
-        this.parseAndCheck("type1/subtype1",
+        this.parseStringAndCheck("type1/subtype1",
                 MediaType.with("type1", "subtype1"));
     }
 
     @Test
     public void testParseWithUnquotedParameter() {
-        this.parseAndCheck("type1/subtype1;abc=def",
+        this.parseStringAndCheck("type1/subtype1;abc=def",
                 MediaType.with("type1", "subtype1")
                         .setParameters(Maps.of(MediaTypeParameterName.with("abc"), "def")));
     }
 
     @Test
     public void testParseWithQuotedParameter() {
-        this.parseAndCheck("type1/subtype1;abc=\"d,\\\\ef\"",
+        this.parseStringAndCheck("type1/subtype1;abc=\"d,\\\\ef\"",
                 MediaType.with("type1", "subtype1")
                         .setParameters(Maps.of(MediaTypeParameterName.with("abc"), "d,\\ef")));
     }
 
     @Test
     public void testParseWithBoundary() {
-        this.parseAndCheck("type1/subtype1;boundary=def",
+        this.parseStringAndCheck("type1/subtype1;boundary=def",
                 MediaType.with("type1", "subtype1")
                         .setParameters(Maps.of(MediaTypeParameterName.BOUNDARY, MediaTypeBoundary.with("def"))));
     }
 
     @Test
     public void testParseWithTitleStar() {
-        this.parseAndCheck("type1/subtype1;title*=UTF-8''abc%20123",
+        this.parseStringAndCheck("type1/subtype1;title*=UTF-8''abc%20123",
                 MediaType.with("type1", "subtype1")
                         .setParameters(Maps.of(MediaTypeParameterName.TITLE_STAR, EncodedText.with(CharsetName.UTF_8, EncodedText.NO_LANGUAGE, "abc 123"))));
     }
@@ -460,7 +460,7 @@ final public class MediaTypeTest extends HeaderValueWithParametersTestCase<Media
     // ParseStringTesting ........................................................................................
 
     @Override
-    public MediaType parse(final String text) {
+    public MediaType parseString(final String text) {
         return MediaType.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/QuotedStringHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/QuotedStringHeaderValueHandlerTest.java
@@ -53,19 +53,19 @@ public final class QuotedStringHeaderValueHandlerTest extends StringHeaderValueH
 
     @Test
     public void testParse() {
-        this.parseAndCheck("\"abc\"", "abc");
+        this.parseStringAndCheck("\"abc\"", "abc");
     }
 
     @Test
     public void testParseWithBackslashSupportedEscapedDoubleQuote() {
-        this.parseAndCheck(this.handlerSupportingBackslashes(),
+        this.parseStringAndCheck(this.handlerSupportingBackslashes(),
                 "\"a\\\"bc\"",
                 "a\"bc");
     }
 
     @Test
     public void testParseWithBackslashSupportedEscapedBackslash() {
-        this.parseAndCheck(this.handlerSupportingBackslashes(),
+        this.parseStringAndCheck(this.handlerSupportingBackslashes(),
                 "\"a\\\\bc\"",
                 "a\\bc");
     }
@@ -107,7 +107,7 @@ public final class QuotedStringHeaderValueHandlerTest extends StringHeaderValueH
         final String text = "\"a\\\"bc\"";
         final String value = "a\"bc";
 
-        this.parseAndCheck(handler, text, value);
+        this.parseStringAndCheck(handler, text, value);
         this.toTextAndCheck(handler, value, text);
     }
 

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueHeaderValueHandlerTest.java
@@ -33,7 +33,7 @@ public final class RangeHeaderValueHeaderValueHandlerTest extends
 
     @Test
     public void testParseRangeHeader() {
-        this.parseAndCheck(TEXT, this.range());
+        this.parseStringAndCheck(TEXT, this.range());
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueTest.java
@@ -174,60 +174,60 @@ public final class RangeHeaderValueTest extends HeaderValueTestCase<RangeHeaderV
 
     @Test
     public void testParseWithInvalidUnitFails() {
-        this.parseFails2("invalid=0-100");
+        this.parseStringFails2("invalid=0-100");
     }
 
     @Test
     public void testParseWithNoneUnitFails() {
-        this.parseFails2("none=0-100");
+        this.parseStringFails2("none=0-100");
     }
 
     @Test
     public void testParseWithOverlapFails() {
-        this.parseFails2("bytes=100-150,200-250,225-300");
+        this.parseStringFails2("bytes=100-150,200-250,225-300");
     }
 
     @Test
     public void testParseWithOverlapFails2() {
-        this.parseFails2("bytes=100-150,200-250,225-");
+        this.parseStringFails2("bytes=100-150,200-250,225-");
     }
 
     @Test
     public void testParseWithOverlapFails3() {
-        this.parseFails2("bytes=-150,200-250,125-175");
+        this.parseStringFails2("bytes=-150,200-250,125-175");
     }
 
     @Test
     public void testParseRangeMissingStartFails() {
-        this.parseFails2("bytes=-99");
+        this.parseStringFails2("bytes=-99");
     }
 
     @Test
     public void testParseRangeMissingStartFails2() {
-        this.parseFails2("bytes=98-99,-50");
+        this.parseStringFails2("bytes=98-99,-50");
     }
 
-    private void parseFails2(final String text) {
-        this.parseFails(text, HeaderValueException.class);
+    private void parseStringFails2(final String text) {
+        this.parseStringFails(text, HeaderValueException.class);
     }
 
     @Test
     public void testParseOpenRange() {
-        this.parseAndCheck("bytes=123-",
+        this.parseStringAndCheck("bytes=123-",
                 UNIT,
                 this.rangeGte123());
     }
 
     @Test
     public void testParseClosedRange() {
-        this.parseAndCheck("bytes=123-456",
+        this.parseStringAndCheck("bytes=123-456",
                 UNIT,
                 this.rangeGte123().and(this.rangeLte456()));
     }
 
     @Test
     public void testParseClosedCommaRangeOpen() {
-        this.parseAndCheck("bytes=123-456,789-",
+        this.parseStringAndCheck("bytes=123-456,789-",
                 UNIT,
                 this.rangeGte123().and(this.rangeLte456()),
                 this.rangeGte789());
@@ -235,7 +235,7 @@ public final class RangeHeaderValueTest extends HeaderValueTestCase<RangeHeaderV
 
     @Test
     public void testParseClosedCommaWhitespaceRangeOpen() {
-        this.parseAndCheck("bytes=123-456, 789-",
+        this.parseStringAndCheck("bytes=123-456, 789-",
                 UNIT,
                 this.rangeGte123().and(this.rangeLte456()),
                 this.rangeGte789());
@@ -243,7 +243,7 @@ public final class RangeHeaderValueTest extends HeaderValueTestCase<RangeHeaderV
 
     @Test
     public void testParseClosedCommaWhitespaceRangeOpen2() {
-        this.parseAndCheck("bytes=123-456,  789-",
+        this.parseStringAndCheck("bytes=123-456,  789-",
                 UNIT,
                 this.rangeGte123().and(this.rangeLte456()),
                 this.rangeGte789());
@@ -251,23 +251,23 @@ public final class RangeHeaderValueTest extends HeaderValueTestCase<RangeHeaderV
 
     @Test
     public void testParseClosedCommaRangeClosed() {
-        this.parseAndCheck("bytes=123-456,789-1000",
+        this.parseStringAndCheck("bytes=123-456,789-1000",
                 UNIT,
                 this.rangeGte123().and(this.rangeLte456()),
                 this.rangeGte789().and(this.rangeLte1000()));
     }
 
     @SafeVarargs
-    private final void parseAndCheck(final String text,
+    private final void parseStringAndCheck(final String text,
                                      final RangeHeaderValueUnit unit,
                                      final Range<Long>... values) {
-        this.parseAndCheck(text, RangeHeaderValue.with(unit, Lists.of(values)));
+        this.parseStringAndCheck(text, RangeHeaderValue.with(unit, Lists.of(values)));
     }
 
     // ParseStringTesting ........................................................................................
 
     @Override
-    public RangeHeaderValue parse(final String text) {
+    public RangeHeaderValue parseString(final String text) {
         return RangeHeaderValue.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitHeaderValueHandlerTest.java
@@ -31,7 +31,7 @@ public final class RangeHeaderValueUnitHeaderValueHandlerTest extends
 
     @Test
     public void testParseRangeHeader() {
-        this.parseAndCheck(TEXT, this.range());
+        this.parseStringAndCheck(TEXT, this.range());
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitTest.java
+++ b/src/test/java/walkingkooka/net/header/RangeHeaderValueUnitTest.java
@@ -37,7 +37,7 @@ public final class RangeHeaderValueUnitTest extends HeaderValueTestCase<RangeHea
 
     @Test
     public void testParseUnknownFails() {
-        this.parseFails("unknown", IllegalArgumentException.class);
+        this.parseStringFails("unknown", IllegalArgumentException.class);
     }
 
     @Test
@@ -58,7 +58,7 @@ public final class RangeHeaderValueUnitTest extends HeaderValueTestCase<RangeHea
     // ParseStringTesting ........................................................................................
 
     @Override
-    public RangeHeaderValueUnit parse(final String text) {
+    public RangeHeaderValueUnit parseString(final String text) {
         return RangeHeaderValueUnit.parse(text);
     }
 

--- a/src/test/java/walkingkooka/net/header/UnalteredStringHeaderValueHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/UnalteredStringHeaderValueHandlerTest.java
@@ -35,32 +35,32 @@ public final class UnalteredStringHeaderValueHandlerTest extends StringHeaderVal
     public void testParseAsciiControlCharacters() {
         IntStream.range(0, 31)
                 .filter(i -> i != '\t')
-                .forEach(i -> this.parseAndCheck2("" + Character.toChars(i)));
+                .forEach(i -> this.parseStringAndCheck2("" + Character.toChars(i)));
     }
 
     @Test
     public void testParseNonControlCharacters() {
         IntStream.range(32, 256)
-                .forEach(i -> this.parseAndCheck2( "" + Character.toChars(i)));
+                .forEach(i -> this.parseStringAndCheck2( "" + Character.toChars(i)));
     }
 
     @Test
     public void testParseIncludingComments() {
-        this.parseAndCheck2("Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0");
+        this.parseStringAndCheck2("Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20100101 Firefox/12.0");
     }
 
     @Test
     public void testParseSurroundedWhitespaceKept() {
-        this.parseAndCheck2(" a b c ");
+        this.parseStringAndCheck2(" a b c ");
     }
 
     @Test
     public void testParseDoubleQuoted() {
-        this.parseAndCheck2("\"abc\"");
+        this.parseStringAndCheck2("\"abc\"");
     }
 
-    private void parseAndCheck2(final String text) {
-        this.parseAndCheck(text, text);
+    private void parseStringAndCheck2(final String text) {
+        this.parseStringAndCheck(text, text);
     }
 
     @Test


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka/pull/2087
- ParseStringTesting method names changes avoid ParserTesting clashes