### PR TITLE
HttpRequestAttributeRouting wildcard support improved

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRouting.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRouting.java
@@ -123,24 +123,19 @@ final public class HttpRequestAttributeRouting<T> implements Builder<Routing<Htt
     // path ............................................................................................................
 
     /**
-     * A {@link Predicate} that matches wildcard files within a path.
+     * Adds all path components with support for wildcards. A wildcard simply matches any path components value that is present.
      */
-    public final static Predicate<UrlPathName> PATH_REMOVE_WILDCARDS = Predicates.is(UrlPathName.with("*"));
-
-    /**
-     * Adds all path components that are NOT matched by the {@link Predicate skip}.
-     */
-    public HttpRequestAttributeRouting<T> path(final UrlPath path,
-                                               final Predicate<UrlPathName> skip) {
+    public HttpRequestAttributeRouting<T> path(final UrlPath path) {
         Objects.requireNonNull(path, "path");
-        Objects.requireNonNull(skip, "skip");
 
         HttpRequestAttributeRouting<T> that = this;
 
         int i = 0;
         for (UrlPathName name : path) {
             if (0 != i) {
-                if (false == skip.test(name)) {
+                if (WILDCARD.equals(name)) {
+                    that = that.pathComponent(i, HttpRequestAttributeRoutingWildcardPredicate.INSTANCE);
+                } else {
                     that = that.pathComponent(i, name);
                 }
             }
@@ -149,6 +144,12 @@ final public class HttpRequestAttributeRouting<T> implements Builder<Routing<Htt
 
         return that;
     }
+
+    /**
+     * A wildcard path component.
+     */
+    private final static UrlPathName WILDCARD = UrlPathName.with("*");
+
 
     /**
      * Adds a requirement for a particular path component by name.

--- a/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingWildcardPredicate.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingWildcardPredicate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import walkingkooka.net.UrlPath;
+import walkingkooka.net.UrlPathName;
+
+import java.util.function.Predicate;
+
+/**
+ * A {@link Predicate} used by {@link HttpRequestAttributeRouting#path(UrlPath)} which provides support for matching
+ * wildcard path components. It will return true for any non null {@link UrlPathName}.
+ */
+final class HttpRequestAttributeRoutingWildcardPredicate implements Predicate<UrlPathName> {
+
+    /**
+     * Singleton
+     */
+    final static HttpRequestAttributeRoutingWildcardPredicate INSTANCE = new HttpRequestAttributeRoutingWildcardPredicate();
+
+    /**
+     * Private use singleton.
+     */
+    private HttpRequestAttributeRoutingWildcardPredicate() {
+        super();
+    }
+
+    @Override
+    public boolean test(final UrlPathName pathName) {
+        return null != pathName;
+    }
+
+    @Override
+    public String toString() {
+        return "*";
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingTest.java
@@ -200,23 +200,16 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
     // path UrlPathName, Predicate .....................................................................................
 
     @Test
-    public void testPathPredicateNegativePathComponentIndexFails() {
+    public void testPathNullFails() {
         assertThrows(NullPointerException.class, () -> {
-            this.createRouting().path(null, Predicates.fake());
-        });
-    }
-
-    @Test
-    public void testPathPredicateNullPredicateFails() {
-        assertThrows(NullPointerException.class, () -> {
-            this.createRouting().path(UrlPath.EMPTY, null);
+            this.createRouting().path(null);
         });
     }
 
     @Test
     public void testPathPredicateEmptyPath() {
         final HttpRequestAttributeRouting<?> routing = this.createRouting();
-        assertSame(routing, routing.path(UrlPath.EMPTY, Predicates.fake()));
+        assertSame(routing, routing.path(UrlPath.EMPTY));
 
         this.checkAttributes(routing, Maps.empty());
     }
@@ -224,7 +217,7 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
     @Test
     public void testPathPredicatePath() {
         final HttpRequestAttributeRouting<?> routing = this.createRouting();
-        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("/1a/2b"), Predicates.never());
+        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("/1a/2b"));
         assertNotSame(routing, routing2);
 
         this.checkTransports(routing2);
@@ -239,7 +232,7 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
     @Test
     public void testPathPredicatePathWithoutLeadingSlash() {
         final HttpRequestAttributeRouting<?> routing = this.createRouting();
-        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("1a/2b"), Predicates.never());
+        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("1a/2b"));
         assertNotSame(routing, routing2);
 
         this.checkTransports(routing2);
@@ -254,13 +247,14 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
     @Test
     public void testPathPredicatePathWithWildcard() {
         final HttpRequestAttributeRouting<?> routing = this.createRouting();
-        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("1a/*/3c"), HttpRequestAttributeRouting.PATH_REMOVE_WILDCARDS);
+        final HttpRequestAttributeRouting<?> routing2 = routing.path(UrlPath.parse("1a/*/3c"));
         assertNotSame(routing, routing2);
 
         this.checkTransports(routing2);
         this.checkMethods(routing2);
         this.checkAttributes(routing2,
                 Maps.of(HttpRequestAttributes.pathComponent(1), Predicates.is(UrlPathName.with("1a")),
+                        HttpRequestAttributes.pathComponent(2), HttpRequestAttributeRoutingWildcardPredicate.INSTANCE,
                         HttpRequestAttributes.pathComponent(3), Predicates.is(UrlPathName.with("3c"))));
 
         this.check(routing);
@@ -585,7 +579,7 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
     @Test
     public void testPathBuildAndRoute() {
         final Router<HttpRequestAttribute<?>, String> router = this.router(this.createRouting()
-                .path(UrlPath.parse("/path1/path2"), HttpRequestAttributeRouting.PATH_REMOVE_WILDCARDS));
+                .path(UrlPath.parse("/path1/path2")));
 
         final Map<HttpRequestAttribute<?>, Object> parameters = Maps.ordered();
 
@@ -832,8 +826,8 @@ public final class HttpRequestAttributeRoutingTest implements ClassTesting2<Http
                         .protocolVersion(HttpProtocolVersion.VERSION_1_0)
                         .method(HttpMethod.GET)
                         .method(HttpMethod.POST)
-                        .path(UrlPath.parse("/a1/b2/c3"), HttpRequestAttributeRouting.PATH_REMOVE_WILDCARDS),
-                "GET POST PROTOCOL_VERSION=HTTP/1.0, path-1=a1, path-2=b2, path-3=c3");
+                        .path(UrlPath.parse("/a1/b2/c3/*")),
+                "GET POST PROTOCOL_VERSION=HTTP/1.0, path-1=a1, path-2=b2, path-3=c3, path-4=*");
     }
 
     // helpers..........................................................................................................

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingWildcardPredicateTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestAttributeRoutingWildcardPredicateTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.net.UrlPathName;
+import walkingkooka.predicate.PredicateTesting2;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.test.ToStringTesting;
+import walkingkooka.type.JavaVisibility;
+
+public final class HttpRequestAttributeRoutingWildcardPredicateTest implements PredicateTesting2<HttpRequestAttributeRoutingWildcardPredicate, UrlPathName>,
+        ClassTesting2<HttpRequestAttributeRoutingWildcardPredicate>,
+        ToStringTesting<HttpRequestAttributeRoutingWildcardPredicate> {
+
+    @Override
+    public void testTestNullFails() {
+    }
+
+    @Test
+    public void testNonNullTrue() {
+        this.testTrue(UrlPathName.with("abc"));
+    }
+
+    @Test
+    public void testNonNullTrue2() {
+        this.testTrue(UrlPathName.with("123"));
+    }
+
+    @Test
+    public void testWildcardTrue() {
+        this.testTrue(UrlPathName.with("*"));
+    }
+
+    @Test
+    public void testNullFalse() {
+        this.testFalse(null);
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createPredicate(), "*");
+    }
+
+    @Override
+    public HttpRequestAttributeRoutingWildcardPredicate createPredicate() {
+        return HttpRequestAttributeRoutingWildcardPredicate.INSTANCE;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+
+    @Override
+    public Class<HttpRequestAttributeRoutingWildcardPredicate> type() {
+        return HttpRequestAttributeRoutingWildcardPredicate.class;
+    }
+}


### PR DESCRIPTION
- Previously HttpRequestAttributeRouting.path skipped wildcards within a path, now a Predicate verifies they are present during routing.