### PR TITLE
travis timeout fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,18 @@ language: java
 jdk:
 - oraclejdk9
 
+install: mvn dependency:resolve
+
+before_script:
+  - echo "MAVEN_OPTS='-Xmx3g -XX:MaxPermSize=800m'" > ~/.mavenrc
+
+script:
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -e
+
 after_success:
-- mvn jacoco:report coveralls:report
+  - mvn jacoco:report coveralls:report
+
+after_failure:
+  - tail -n 500 target/it-tests/junit-test/build.log
 
 dist: trusty

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.20.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.junit.platform</groupId>
@@ -220,7 +220,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/junit-test/pom.xml
+++ b/src/it/junit-test/pom.xml
@@ -164,6 +164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.20.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
- travis increased no output timeout.
- maven-invoker-plugin: debug=true, stream=false
- surefire upgraded to 2.20.1 (https://travis-ci.community/t/outofmemoryerror-error-occurs-when-adding-vintage-junit/9285)
- install performs: mvn -v (version)
- increased memory and permsize
- changes to run mvn from script rather than install redirected to a file and then tail that file on failure.