### PR TITLE
HttpEntity.with(Map, Binary) removed

### DIFF
--- a/src/main/java/walkingkooka/net/http/HttpEntity.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntity.java
@@ -92,8 +92,9 @@ public final class HttpEntity implements HasHeaders {
     /**
      * Creates a new {@link HttpEntity}
      */
-    public static HttpEntity with(final Map<HttpHeaderName<?>, Object> headers,
-                                  final Binary body) {
+    // @VisibleForTesting
+    static HttpEntity with(final Map<HttpHeaderName<?>, Object> headers,
+                           final Binary body) {
         return new HttpEntity(checkHeaders(headers), checkBody(body));
     }
 

--- a/src/test/java/walkingkooka/net/http/server/AutoContentLengthHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/AutoContentLengthHttpResponseTest.java
@@ -65,13 +65,11 @@ public final class AutoContentLengthHttpResponseTest extends WrapperHttpRequestH
                     }
                 });
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
-        if (null != contentLength) {
-            headers.put(HttpHeaderName.CONTENT_LENGTH, contentLength);
-        }
         final Binary bodyBinary = Binary.with(body);
-        response.addEntity(HttpEntity.with(headers, bodyBinary));
-        assertEquals(Lists.of(HttpEntity.with(Maps.of(HttpHeaderName.CONTENT_LENGTH, (long) body.length), bodyBinary)),
+        response.addEntity((null == contentLength ?
+                HttpEntity.EMPTY :
+                HttpEntity.EMPTY.addHeader(HttpHeaderName.CONTENT_LENGTH, contentLength)).setBody(bodyBinary));
+        assertEquals(Lists.of(HttpEntity.EMPTY.addHeader(HttpHeaderName.CONTENT_LENGTH, (long) body.length).setBody(bodyBinary)),
                 added,
                 "added entity");
     }

--- a/src/test/java/walkingkooka/net/http/server/AutoGzipEncodingHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/AutoGzipEncodingHttpResponseTest.java
@@ -125,7 +125,7 @@ public final class AutoGzipEncodingHttpResponseTest extends WrapperHttpRequestHt
 
                     @Test
                     public void addEntity(final HttpEntity e) {
-                        assertEquals(HttpEntity.with(expectedHeaders, Binary.with(expectedBody)),
+                        assertEquals(httpEntity(expectedHeaders).setBody(Binary.with(expectedBody)),
                                 e,
                                 "entity");
                         addEntity++;
@@ -134,7 +134,7 @@ public final class AutoGzipEncodingHttpResponseTest extends WrapperHttpRequestHt
         if (null != contentEncoding) {
             headers.put(HttpHeaderName.CONTENT_ENCODING, ContentEncoding.parse(contentEncoding));
         }
-        response.addEntity(HttpEntity.with(headers, Binary.with(body)));
+        response.addEntity(httpEntity(headers).setBody(Binary.with(body)));
         assertEquals(1, this.addEntity, "wrapped response addEntity(body) not called");
     }
 

--- a/src/test/java/walkingkooka/net/http/server/DefaultHeadersHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/DefaultHeadersHttpResponseTest.java
@@ -63,9 +63,11 @@ public final class DefaultHeadersHttpResponseTest extends WrapperHttpResponseTes
         final HttpRequest request = HttpRequests.fake();
         DefaultHeadersHttpResponse response = this.createResponse(request, recording);
         response.setStatus(status);
-        response.addEntity(HttpEntity.with(responseHeaders, body));
+        response.addEntity(httpEntity(responseHeaders).setBody(body));
 
-        final HttpEntity second = HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "Server2"), Binary.with(new byte[2]));
+        final HttpEntity second = HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.SERVER, "Server2")
+                .setBody(Binary.with(new byte[2]));
         response.addEntity(second);
 
         final Map<HttpHeaderName<?>, Object> finalHeaders = Maps.ordered();
@@ -75,7 +77,7 @@ public final class DefaultHeadersHttpResponseTest extends WrapperHttpResponseTes
         this.checkResponse(recording,
                 request,
                 status,
-                HttpEntity.with(finalHeaders, body),
+                httpEntity(finalHeaders).setBody(body),
                 second);
     }
 

--- a/src/test/java/walkingkooka/net/http/server/HeadHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HeadHttpResponseTest.java
@@ -66,12 +66,12 @@ public final class HeadHttpResponseTest extends WrapperHttpRequestHttpResponseTe
     public void testHeadIgnoreResponseBody() {
         final Map<HttpHeaderName<?>, Object> headers = this.headers();
 
-        for (HttpStatusCode status : HttpStatusCode.values()) {
+        for (final HttpStatusCode status : HttpStatusCode.values()) {
             this.setStatusAddEntityAndCheck(this.createRequest(HttpMethod.HEAD),
                     status.status(),
-                    HttpEntity.with(headers, Binary.with(new byte[CONTENT_LENGTH])),
+                    httpEntity(headers).setBody(Binary.with(new byte[CONTENT_LENGTH])),
                     status.status(),
-                    HttpEntity.with(headers, HttpEntity.NO_BODY));
+                    httpEntity(headers));
         }
     }
 
@@ -86,18 +86,16 @@ public final class HeadHttpResponseTest extends WrapperHttpRequestHttpResponseTe
 
         response.setStatus(status);
 
-        final Binary body = Binary.with(new byte[CONTENT_LENGTH]);
-        final HttpEntity first = HttpEntity.with(headers, body);
-        response.addEntity(first);
+        response.addEntity(httpEntity(headers).setBody(Binary.with(new byte[CONTENT_LENGTH])));
 
         final byte[] bytes2 = new byte[CONTENT_LENGTH];
         Arrays.fill(bytes2, (byte) 'A');
-        response.addEntity(HttpEntity.with(headers, Binary.with(bytes2)));
+        response.addEntity(httpEntity(headers).setBody(Binary.with(bytes2)));
 
         this.checkResponse(recording,
                 request,
                 status,
-                HttpEntity.with(headers, HttpEntity.NO_BODY));
+                httpEntity(headers));
     }
 
     private Map<HttpHeaderName<?>, Object> headers() {

--- a/src/test/java/walkingkooka/net/http/server/HttpStatusCodeRequiredHeadersHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpStatusCodeRequiredHeadersHttpResponseTest.java
@@ -31,7 +31,6 @@ import walkingkooka.net.http.HttpStatusCode;
 import walkingkooka.net.http.HttpStatusCodeCategory;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -56,14 +55,16 @@ public final class HttpStatusCodeRequiredHeadersHttpResponseTest extends Bufferi
     @Test
     public void testSuccessMultiPart() {
         this.setStatusAddEntityAndCheck(HttpStatusCode.OK.status(),
-                HttpEntity.with(Maps.of(HttpHeaderName.CONTENT_TYPE, MediaType.parse("multipart/text")), this.binary("part-1a")),
-                HttpEntity.with(Maps.of(HttpHeaderName.CONTENT_TYPE, MediaType.parse("multipart/text")), this.binary("part-2b")));
+                HttpEntity.EMPTY.addHeader(HttpHeaderName.CONTENT_TYPE, MediaType.parse("multipart/text")).setBody(this.binary("part-1a")),
+                HttpEntity.EMPTY.addHeader(HttpHeaderName.CONTENT_TYPE, MediaType.parse("multipart/text")).setBody(this.binary("part-2b")));
     }
 
     @Test
     public void testPartialContentWithRanges() {
         this.setStatusAddEntityAndCheck(HttpStatusCode.PARTIAL_CONTENT.status(),
-                HttpEntity.with(Maps.of(HttpHeaderName.RANGE, RangeHeaderValue.parse("bytes=1-2")), this.binary("a1")));
+                HttpEntity.EMPTY
+                        .addHeader(HttpHeaderName.RANGE, RangeHeaderValue.parse("bytes=1-2"))
+                        .setBody(this.binary("a1")));
     }
 
     @Test
@@ -189,11 +190,11 @@ public final class HttpStatusCodeRequiredHeadersHttpResponseTest extends Bufferi
 
     private void setStatusWithoutLocationHeader(final HttpStatusCode code) {
         this.setStatusAddEntityAndCheck(code.status(),
-                HttpEntity.with(Maps.of(HttpHeaderName.LOCATION, Url.parse("http://example.com")), this.binary("a1")));
+                HttpEntity.EMPTY.addHeader(HttpHeaderName.LOCATION, Url.parse("http://example.com")).setBody(this.binary("a1")));
     }
 
     private HttpEntity httpEntityWithServerHeader() {
-        return HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "Server123"), this.binary("a1"));
+        return HttpEntity.EMPTY.addHeader(HttpHeaderName.SERVER, "Server123").setBody(this.binary("a1"));
     }
 
     private Binary binary(final String content) {
@@ -207,12 +208,12 @@ public final class HttpStatusCodeRequiredHeadersHttpResponseTest extends Bufferi
     private void missingRequiredHeaderFails(final HttpStatusCode code,
                                             final Map<HttpHeaderName<?>, Object> headers) {
         final HttpStatus status = code.status();
-        final HttpEntity entity = HttpEntity.with(headers, Binary.with(new byte[]{'a', 'b', 'c', '1', '2', '3'}));
+        final HttpEntity entity = httpEntity(headers).setBody(Binary.with(new byte[]{'a', 'b', 'c', '1', '2', '3'}));
 
         this.setStatusAddEntityAndCheck(status,
-                Lists.of(entity, HttpEntity.with(Maps.of(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN), Binary.EMPTY)),
+                Lists.of(entity, HttpEntity.EMPTY.addHeader(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN)),
                 HttpStatusCode.INTERNAL_SERVER_ERROR.status(),
-                HttpEntity.with(HttpEntity.NO_HEADERS, Binary.EMPTY));
+                HttpEntity.EMPTY);
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/IfNoneMatchAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/IfNoneMatchAwareHttpResponseTest.java
@@ -220,9 +220,9 @@ public final class IfNoneMatchAwareHttpResponseTest extends BufferingHttpRespons
         this.setStatusAddEntityAndCheck(
                 this.createRequest(),
                 status.status(),
-                HttpEntity.with(headers, Binary.with(body)),
+                httpEntity(headers).setBody(Binary.with(body)),
                 expectedStatus.status(),
-                HttpEntity.with(expectedHeaders, Binary.with(expectedBody)));
+                httpEntity(expectedHeaders).setBody(Binary.with(expectedBody)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/LastModifiedAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/LastModifiedAwareHttpResponseTest.java
@@ -25,7 +25,6 @@ import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.ETag;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
-import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpStatusCode;
 
@@ -243,9 +242,9 @@ public final class LastModifiedAwareHttpResponseTest extends BufferingHttpRespon
         this.setStatusAddEntityAndCheck(
                 createRequest(),
                 status.status(),
-                HttpEntity.with(headers, Binary.with(body)),
+                httpEntity(headers).setBody(Binary.with(body)),
                 expectedStatus.status(),
-                HttpEntity.with(expectedHeaders, Binary.with(expectedBody)));
+                httpEntity(expectedHeaders).setBody(Binary.with(expectedBody)));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/MultiPartAwareHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/MultiPartAwareHttpResponseTest.java
@@ -20,7 +20,6 @@ package walkingkooka.net.http.server;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Binary;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpEntity;
@@ -84,8 +83,12 @@ public final class MultiPartAwareHttpResponseTest extends BufferingHttpResponseT
                 this.entity(HttpHeaderName.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA, "part2"));
     }
 
-    private <TT> HttpEntity entity(final HttpHeaderName<TT> header, final TT value, final String content) {
-        return HttpEntity.with(Maps.of(header, value), Binary.with(content.getBytes(Charset.defaultCharset())));
+    private <TT> HttpEntity entity(final HttpHeaderName<TT> header,
+                                   final TT value,
+                                   final String content) {
+        return HttpEntity.EMPTY
+                .addHeader(header, value)
+                .setBody(Binary.with(content.getBytes(Charset.defaultCharset())));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/RecordingHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/RecordingHttpResponseTest.java
@@ -20,13 +20,10 @@ package walkingkooka.net.http.server;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Binary;
 import walkingkooka.collect.list.Lists;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.net.http.HttpStatusCode;
-import walkingkooka.reflect.ClassTesting2;
-import walkingkooka.reflect.JavaVisibility;
 
 import java.util.Optional;
 
@@ -62,7 +59,9 @@ public final class RecordingHttpResponseTest extends HttpResponseTestCase2<Recor
         final RecordingHttpResponse response = this.createResponse();
         final HttpStatus status = this.status();
         final HttpEntity entity = this.entity();
-        final HttpEntity entity2 = HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "part 2"), Binary.with(new byte[123]));
+        final HttpEntity entity2 = HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.SERVER, "part 2")
+                .setBody(Binary.with(new byte[123]));
         response.setStatus(status);
         response.addEntity(entity);
         response.addEntity(entity2);
@@ -87,13 +86,17 @@ public final class RecordingHttpResponseTest extends HttpResponseTestCase2<Recor
     public void testCheckDifferentEntityFails() {
         final RecordingHttpResponse response = this.createResponse();
         final HttpStatus status = this.status();
-        final HttpEntity entity = HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "Server 123"), Binary.with(new byte[123]));
+        final HttpEntity entity = HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.SERVER, "Server 123")
+                .setBody(Binary.with(new byte[123]));
         response.setStatus(status);
         response.addEntity(entity);
 
         assertThrows(AssertionError.class, () -> this.checkResponse(response, HttpRequests.fake(),
                 status,
-                HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "Server 456"), Binary.with(new byte[456]))));
+                HttpEntity.EMPTY
+                        .addHeader(HttpHeaderName.SERVER, "Server 456")
+                        .setBody(Binary.with(new byte[456]))));
     }
 
     @Test
@@ -119,7 +122,9 @@ public final class RecordingHttpResponseTest extends HttpResponseTestCase2<Recor
     }
 
     private HttpEntity entity() {
-        return HttpEntity.with(Maps.of(HttpHeaderName.SERVER, "Server 123"), Binary.with(new byte[]{65, 66, 67}));
+        return HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.SERVER, "Server 123")
+                .setBody(Binary.with(new byte[]{65, 66, 67}));
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/http/server/RequiredHeadersHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/RequiredHeadersHttpResponseTest.java
@@ -20,14 +20,11 @@ package walkingkooka.net.http.server;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Binary;
 import walkingkooka.Cast;
-import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpProtocolVersion;
 import walkingkooka.net.http.HttpStatusCode;
-
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -110,16 +107,14 @@ public final class RequiredHeadersHttpResponseTest extends BufferingHttpResponse
     }
 
     private HttpEntity entityWithoutServerHeader() {
-        return HttpEntity.with(Maps.of(HttpHeaderName.CONTENT_TYPE, MediaType.BINARY),
-                Binary.with(new byte[]{'a'}));
+        return HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.CONTENT_TYPE, MediaType.BINARY)
+                .setBody(Binary.with(new byte[]{'a'}));
     }
 
     private HttpEntity entityWithServerHeader() {
-        final Map<HttpHeaderName<?>, Object> headers = Maps.ordered();
-        headers.put(HttpHeaderName.CONTENT_TYPE, MediaType.BINARY);
-        headers.put(HttpHeaderName.SERVER, "Server 123");
-
-        return HttpEntity.with(headers, Binary.with(new byte[]{'a'}));
+        return this.entityWithoutServerHeader()
+                .addHeader(HttpHeaderName.SERVER, "Server 123");
     }
     
 

--- a/src/test/java/walkingkooka/net/http/server/WebFileHttpRequestHttpResponseBiConsumerTest.java
+++ b/src/test/java/walkingkooka/net/http/server/WebFileHttpRequestHttpResponseBiConsumerTest.java
@@ -166,12 +166,11 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.OK.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1);
-
-        expected.addEntity(HttpEntity.with(headers, CONTENT1));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1)
+                .setBody(CONTENT1));
 
         this.checkResponse(request, response, expected);
     }
@@ -187,12 +186,11 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.OK.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1);
-
-        expected.addEntity(HttpEntity.with(headers, CONTENT1));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1)
+                .setBody(CONTENT1));
 
         this.checkResponse(request, response, expected);
     }
@@ -208,13 +206,12 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.OK.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED2);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT2.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE2);
-        headers.put(HttpHeaderName.E_TAG, ETAG2);
-
-        expected.addEntity(HttpEntity.with(headers, CONTENT2));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED2)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH,  (long)CONTENT2.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE2)
+                .addHeader(HttpHeaderName.E_TAG, ETAG2)
+                .setBody(CONTENT2));
 
         this.checkResponse(request, response, expected);
     }
@@ -230,12 +227,10 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.NOT_MODIFIED.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1);
-
-        expected.addEntity(HttpEntity.with(headers, HttpEntity.NO_BODY));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH, (long) CONTENT1.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1));
 
         this.checkResponse(request, response, expected);
     }
@@ -251,12 +246,11 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.OK.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1);
-
-        expected.addEntity(HttpEntity.with(headers, CONTENT1));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED1)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT1.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE1)
+                .setBody(CONTENT1));
 
         this.checkResponse(request, response, expected);
     }
@@ -272,13 +266,11 @@ public final class WebFileHttpRequestHttpResponseBiConsumerTest implements Class
         final HttpResponse expected = HttpResponses.recording();
         expected.setStatus(HttpStatusCode.NOT_MODIFIED.status());
 
-        final Map<HttpHeaderName<?>, Object> headers = Maps.sorted();
-        headers.put(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED2);
-        headers.put(HttpHeaderName.CONTENT_LENGTH, (long)CONTENT2.size());
-        headers.put(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE2);
-        headers.put(HttpHeaderName.E_TAG, ETAG2);
-
-        expected.addEntity(HttpEntity.with(headers, HttpEntity.NO_BODY));
+        expected.addEntity(HttpEntity.EMPTY
+                .addHeader(HttpHeaderName.LAST_MODIFIED, LAST_MODIFIED2)
+                .addHeader(HttpHeaderName.CONTENT_LENGTH, (long) CONTENT2.size())
+                .addHeader(HttpHeaderName.CONTENT_TYPE, CONTENT_TYPE2)
+                .addHeader(HttpHeaderName.E_TAG, ETAG2));
 
         this.checkResponse(request, response, expected);
     }

--- a/src/test/java/walkingkooka/net/http/server/WrapperHttpResponseTestCase.java
+++ b/src/test/java/walkingkooka/net/http/server/WrapperHttpResponseTestCase.java
@@ -18,12 +18,16 @@
 package walkingkooka.net.http.server;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpStatus;
 import walkingkooka.net.http.HttpStatusCode;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -88,6 +92,16 @@ public abstract class WrapperHttpResponseTestCase<R extends WrapperHttpResponse>
     abstract HttpRequest createRequest();
 
     abstract R createResponse(final HttpRequest request, final HttpResponse response);
+
+    final HttpEntity httpEntity(final Map<HttpHeaderName<?>, Object> headers) {
+        HttpEntity httpEntity = HttpEntity.EMPTY;
+
+        for(final Entry<HttpHeaderName<?>, Object> headerAndValue : headers.entrySet()) {
+            httpEntity = httpEntity.addHeader(headerAndValue.getKey(), Cast.to(headerAndValue.getValue()));
+        }
+
+        return httpEntity;
+    }
 
     final void setStatusAddEntityAndCheck(final HttpStatus status,
                                           final HttpEntity entity) {


### PR DESCRIPTION
- Previous calls to HttpEntity.with(Map, Binary) assemble using HttpEntity.EMPTY.addHeader.setBody