### PR TITLE
HttpRequest j2cl compatible

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -55,6 +55,10 @@ import walkingkooka.net.header.MediaType;
 import walkingkooka.net.header.RangeHeaderValue;
 import walkingkooka.net.header.RangeHeaderValueUnit;
 import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpMethod;
+import walkingkooka.net.http.HttpProtocolVersion;
+import walkingkooka.net.http.HttpTransport;
+import walkingkooka.net.http.server.HttpRequests;
 
 import java.util.Optional;
 
@@ -194,5 +198,16 @@ public class JunitTest {
                 .setBodyText(text);
 
         Assert.assertEquals(text, entity.bodyText());
+    }
+
+    @Test
+    public void testHttpRequest() {
+        HttpRequests.value(HttpMethod.POST,
+                HttpTransport.SECURED,
+                Url.parseRelative("/path1/path2?query3=value4"),
+                HttpProtocolVersion.VERSION_1_1,
+                HttpEntity.EMPTY
+                        .addHeader(HttpHeaderName.CONTENT_LENGTH, 123L)
+                        .setBodyText("different-body-text"));
     }
 }

--- a/src/main/java/walkingkooka/net/http/server/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
+++ b/src/main/java/walkingkooka/net/http/server/.walkingkooka-j2cl-maven-plugin-ignored-files.txt
@@ -4,20 +4,13 @@
 
 *Testing*.*
 
-Fake*
-
 HeaderScope*
-HttpRequest.java
-HttpRequest.class
-HttpRequests*
 
 HttpRequestAttributeRouting*
 HttpRequestAttributes.*
 HttpRequestAttributeUrlPathName.*
 
 HttpRequestRouter*
-
-HttpRequestValue.*
 
 *HttpResponse*
 

--- a/src/main/java/walkingkooka/net/http/server/HttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequest.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.RelativeUrl;
 import walkingkooka.net.header.HttpHeaderName;
@@ -26,10 +27,8 @@ import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.HttpProtocolVersion;
 import walkingkooka.net.http.HttpTransport;
 
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Defines a HTTP request.
@@ -91,6 +90,7 @@ public interface HttpRequest extends HasHeaders {
     /**
      * Returns a {@link Map} of all {@link HttpRequestAttribute} parameters.
      */
+    @GwtIncompatible
     default Map<HttpRequestAttribute<?>, Object> routerParameters() {
         return HttpRequestRouterParametersMap.with(this);
     }

--- a/src/main/java/walkingkooka/net/http/server/HttpRequests.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequests.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.http.server;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import walkingkooka.net.RelativeUrl;
 import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpMethod;
@@ -38,6 +39,7 @@ public final class HttpRequests implements PublicStaticHelper {
     /**
      * {@see HeaderScopeHttpRequest}
      */
+    @GwtIncompatible
     public static HttpRequest headerScope(final HttpRequest request) {
         return HeaderScopeHttpRequest.with(request);
     }
@@ -45,6 +47,7 @@ public final class HttpRequests implements PublicStaticHelper {
     /**
      * {@see HttpServletRequestHttpRequest}
      */
+    @GwtIncompatible
     public static HttpRequest httpServletRequest(final HttpServletRequest request) {
         return HttpServletRequestHttpRequest.with(request);
     }


### PR DESCRIPTION
- HttpRequests and several HttpRequest implementations made j2cl compatible.