### PR TITLE
header.j2cl sub package replaced

### DIFF
--- a/src/main/java/.walkingkooka-j2cl-maven-plugin-shade.txt
+++ b/src/main/java/.walkingkooka-j2cl-maven-plugin-shade.txt
@@ -1,4 +1,0 @@
-#
-# CharsetNameSupport and ContentDispositionFileNameSupport must replace the originals
-#
-walkingkooka.net.header.j2cl=walkingkooka.net.header

--- a/src/main/java/walkingkooka/net/header/CharsetNameSupport.java
+++ b/src/main/java/walkingkooka/net/header/CharsetNameSupport.java
@@ -17,6 +17,8 @@
 
 package walkingkooka.net.header;
 
+import javaemul.internal.annotations.GwtIncompatible;
+
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Set;
@@ -24,11 +26,12 @@ import java.util.Set;
 /**
  * This class has several helpers which include APIS that are not available in the J2cl emulated JRE
  */
-final class CharsetNameSupport {
+final class CharsetNameSupport extends CharsetNameSupportJ2cl {
 
     /**
      * J2cl will require a version of this class that does nothing because {@link Charset#aliases()}.
      */
+    @GwtIncompatible
     static void registerCharsetAliases(final Charset charset,
                                        final Map<String, CharsetName> constants) {
         for (final String alias : charset.aliases()) {
@@ -39,6 +42,7 @@ final class CharsetNameSupport {
     /**
      * The J2cl version of this method will contain no logic and simply return false.
      */
+    @GwtIncompatible
     static boolean testCharsetAliases(final Charset charset,
                                       final Charset aliasSource) {
         final Set<String> contentTypeAliases = aliasSource.aliases();

--- a/src/main/java/walkingkooka/net/header/CharsetNameSupportJ2cl.java
+++ b/src/main/java/walkingkooka/net/header/CharsetNameSupportJ2cl.java
@@ -15,17 +15,24 @@
  *
  */
 
-package walkingkooka.net.header.j2cl;
+package walkingkooka.net.header;
 
-import walkingkooka.reflect.StaticHelper;
+import java.nio.charset.Charset;
+import java.util.Map;
 
-final class ContentDispositionFileNameSupport implements StaticHelper {
-
-    static boolean isFileSeperator(final char c) {
-        return false; // the test with slash in ContentDispositionFileName will have to do.
+/**
+ * This class has several helpers which shadow methods in {@link CharsetNameSupport} which will be eliminated as they
+ * are marked with @GwtIncompatible.
+ */
+class CharsetNameSupportJ2cl {
+    
+    static void registerCharsetAliases(final Charset charset,
+                                       final Map<String, CharsetName> constants) {
+        // j2cl Charset has no aliases.
     }
 
-    private ContentDispositionFileNameSupport() {
-        throw new UnsupportedOperationException();
+    static boolean testCharsetAliases(final Charset charset,
+                                      final Charset aliasSource) {
+        return false;
     }
 }

--- a/src/main/java/walkingkooka/net/header/ContentDispositionFileNameSupportJ2cl.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionFileNameSupportJ2cl.java
@@ -15,25 +15,13 @@
  *
  */
 
-package walkingkooka.net.header.j2cl;
+package walkingkooka.net.header;
 
-import walkingkooka.net.header.CharsetName;
+import walkingkooka.reflect.StaticHelper;
 
-import java.nio.charset.Charset;
-import java.util.Map;
+class ContentDispositionFileNameSupportJ2cl implements StaticHelper {
 
-/**
- * This class has several helpers which include APIS that are not available in the J2cl emulated JRE
- */
-final class CharsetNameSupport {
-    
-    static void registerCharsetAliases(final Charset charset,
-                                       final Map<String, CharsetName> constants) {
-        // j2cl Charset has no aliases.
-    }
-
-    static boolean testCharsetAliases(final Charset charset,
-                                      final Charset aliasSource) {
-        return false;
+    static boolean isFileSeperator(final char c) {
+        return false; // the test with slash in ContentDispositionFileName will have to do.
     }
 }

--- a/src/test/java/walkingkooka/net/header/ContentDispositionFileNameSupportJ2clTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionFileNameSupportJ2clTest.java
@@ -17,14 +17,18 @@
 
 package walkingkooka.net.header;
 
-import java.io.File;
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
 
-final class ContentDispositionFileNameSupport extends ContentDispositionFileNameSupportJ2cl {
+public final class ContentDispositionFileNameSupportJ2clTest implements ClassTesting<ContentDispositionFileNameSupportJ2cl> {
 
-    /**
-     * J2cl will replace this method with one that returns false.
-     */
-    static boolean isFileSeperator(final char c) {
-        return File.separatorChar == c;
+    @Override
+    public Class<ContentDispositionFileNameSupportJ2cl> type() {
+        return ContentDispositionFileNameSupportJ2cl.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
     }
 }


### PR DESCRIPTION
- Alternate j2cl methods shadowed by jvm implementation.