### PR TITLE
HttpRequest.bodyLength

### DIFF
--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -281,6 +281,17 @@ public class JunitTest {
     }
 
     @Test
+    public void testBodyLength() {
+        final String bodyText = "Body123";
+        Assert.assertEquals(bodyText.length(), new FakeHttpRequest() {
+            @Override
+            public String bodyText() {
+                return bodyText;
+            }
+        }.bodyLength());
+    }
+
+    @Test
     public void testHttpRequestHttpResponseBiConsumersWebFile() {
         final HttpRequest request = new FakeHttpRequest() {
 

--- a/src/main/java/walkingkooka/net/http/server/HttpRequest.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequest.java
@@ -80,6 +80,13 @@ public interface HttpRequest extends HasHeaders {
     }
 
     /**
+     * Returns the content length of the body/bodyText
+     */
+    default long bodyLength() {
+        return HttpRequestBodyLength.bodyLength(this);
+    }
+
+    /**
      * Returns a {@link Map} of parameters which may be taken from the query string or post data etc, depending on the method.
      */
     Map<HttpRequestParameterName, List<String>> parameters();

--- a/src/main/java/walkingkooka/net/http/server/HttpRequestBodyLength.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestBodyLength.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import javaemul.internal.annotations.GwtIncompatible;
+
+final class HttpRequestBodyLength extends HttpRequestBodyLengthJ2cl {
+
+    @GwtIncompatible
+    static long bodyLength(final HttpRequest request) {
+        return request.body().length;
+    }
+}

--- a/src/main/java/walkingkooka/net/http/server/HttpRequestBodyLengthJ2cl.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestBodyLengthJ2cl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+abstract class HttpRequestBodyLengthJ2cl {
+
+    /**
+     * This method is shadowed by the sub class {@link HttpRequestBodyLength} which will be removed during transpiling.
+     */
+    static long bodyLength(final HttpRequest request) {
+        return request.bodyText().length();
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestBodyLengthJ2clTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestBodyLengthJ2clTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class HttpRequestBodyLengthJ2clTest implements ClassTesting<HttpRequestBodyLengthJ2cl> {
+
+    // ClassTesting.....................................................................................................
+
+    @Override
+    public Class<HttpRequestBodyLengthJ2cl> type() {
+        return HttpRequestBodyLengthJ2cl.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestBodyLengthTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestBodyLengthTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class HttpRequestBodyLengthTest implements ClassTesting<HttpRequestBodyLength> {
+
+    // ClassTesting.....................................................................................................
+
+    @Override
+    public Class<HttpRequestBodyLength> type() {
+        return HttpRequestBodyLength.class;
+    }
+
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PACKAGE_PRIVATE;
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestTest.java
@@ -92,6 +92,11 @@ public final class HttpRequestTest implements ClassTesting<HttpRequest>, JsonNod
                 this.request(contentType, body).bodyText());
     }
 
+    @Test
+    public void testBodyLength() {
+        assertEquals(123L, this.request("text/plain", new byte[123]));
+    }
+
     private HttpRequest request(final String contentType,
                                 final byte[] body) {
         return new HttpRequest() {


### PR DESCRIPTION
- Includes j2cl support to return HttpRequest.bodyText().length() rather than body().length