### PR TITLE
HttpStatus-message cr or nl check

### DIFF
--- a/src/main/java/walkingkooka/net/http/HttpStatus.java
+++ b/src/main/java/walkingkooka/net/http/HttpStatus.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.http;
 
 import walkingkooka.Cast;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.Value;
 import walkingkooka.text.Whitespace;
 
@@ -117,6 +118,15 @@ public final class HttpStatus implements Value<HttpStatusCode> {
 
     private static void checkMessage(final String message) {
         Whitespace.failIfNullOrEmptyOrWhitespace(message, "message");
+
+        final int length = message.length();
+        for (int i = 0; i < length; i++) {
+            switch (message.charAt(i)) {
+                case '\n':
+                case '\r':
+                    throw new InvalidCharacterException(message, i);
+            }
+        }
     }
 
     // replace........................................................................

--- a/src/test/java/walkingkooka/net/http/HttpStatusTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpStatusTest.java
@@ -19,6 +19,7 @@ package walkingkooka.net.http;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.HashCodeEqualsDefinedTesting2;
+import walkingkooka.InvalidCharacterException;
 import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
@@ -82,6 +83,16 @@ final public class HttpStatusTest implements ClassTesting2<HttpStatus>,
 
     private final static HttpStatusCode CODE = HttpStatusCode.OK;
     private final static String MESSAGE = "OK";
+
+    @Test
+    public void testWithMessagesIncludeCrFails() {
+        assertThrows(InvalidCharacterException.class, () -> HttpStatus.with(HttpStatusCode.OK, "message\r123"));
+    }
+
+    @Test
+    public void testWithMessagesIncludeNlFails() {
+        assertThrows(InvalidCharacterException.class, () -> HttpStatus.with(HttpStatusCode.OK, "message\n123"));
+    }
 
     @Test
     public void testWith() {


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/335
- HttpStatus.setMessage should fail if message contains EOL or chop after any EOL