### PR TITLE
ThrowableHttpStatusTranslatorFunction

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/HttpRequestHttpResponseBiConsumers.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestHttpResponseBiConsumers.java
@@ -72,6 +72,13 @@ public final class HttpRequestHttpResponseBiConsumers implements PublicStaticHel
     }
 
     /**
+     * {@see ThrowableHttpStatusTranslatorFunction}
+     */
+    public static Function<Throwable, HttpStatus> throwableTranslator() {
+        return ThrowableHttpStatusTranslatorFunction.INSTANCE;
+    }
+
+    /**
      * {@see WebFileHttpRequestHttpResponseBiConsumer}
      */
     public static BiConsumer<HttpRequest, HttpResponse> webFile(final UrlPath basePath,

--- a/src/main/java/walkingkooka/net/http/server/ThrowableHttpStatusTranslatorFunction.java
+++ b/src/main/java/walkingkooka/net/http/server/ThrowableHttpStatusTranslatorFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import walkingkooka.net.http.HttpStatus;
+import walkingkooka.net.http.HttpStatusCode;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * A {@link Function} that handles translating the following exceptions.
+ * <ul>
+ *     <li>{@link IllegalArgumentException} -> {@link HttpStatusCode#BAD_REQUEST}</li>
+ *     <li>{@link IllegalStateException} -> {@link HttpStatusCode#NOT_FOUND}</li>
+ *     <li>{@link HttpResponseHttpServerException} -> {@link HttpResponseHttpServerException#status()} the entity is ignored</li>
+ *     <li>{@link UnsupportedOperationException} -> {@link HttpStatusCode#NOT_IMPLEMENTED}</li>
+ *     <li>default -> {@link HttpStatusCode#INTERNAL_SERVER_ERROR}</li>
+ * </ul>
+ */
+final class ThrowableHttpStatusTranslatorFunction implements Function<Throwable, HttpStatus> {
+
+    /**
+     * Singleton
+     */
+    final static ThrowableHttpStatusTranslatorFunction INSTANCE = new ThrowableHttpStatusTranslatorFunction();
+
+    private ThrowableHttpStatusTranslatorFunction() {
+        super();
+    }
+
+    @Override
+    public HttpStatus apply(final Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable");
+
+        final HttpStatus status;
+
+        do {
+            if (throwable instanceof IllegalArgumentException) {
+                status = HttpStatusCode.BAD_REQUEST.setMessageOrDefault(throwable.getMessage());
+                break;
+            }
+            if (throwable instanceof IllegalStateException) {
+                status = HttpStatusCode.NOT_FOUND.setMessageOrDefault(throwable.getMessage());
+                break;
+            }
+            if (throwable instanceof HttpResponseHttpServerException) {
+                status = ((HttpResponseHttpServerException) throwable).status();
+                break;
+            }
+            if (throwable instanceof UnsupportedOperationException) {
+                status = HttpStatusCode.NOT_IMPLEMENTED.setMessageOrDefault(throwable.getMessage());
+                break;
+            }
+
+            status = HttpStatusCode.INTERNAL_SERVER_ERROR.setMessageOrDefault(throwable.getMessage());
+        } while (false);
+
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/test/java/walkingkooka/net/http/server/ThrowableHttpStatusTranslatorFunctionTest.java
+++ b/src/test/java/walkingkooka/net/http/server/ThrowableHttpStatusTranslatorFunctionTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.net.http.server;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.net.http.HttpEntity;
+import walkingkooka.net.http.HttpStatus;
+import walkingkooka.net.http.HttpStatusCode;
+import walkingkooka.util.FunctionTesting;
+
+import java.util.Optional;
+
+public final class ThrowableHttpStatusTranslatorFunctionTest implements FunctionTesting<ThrowableHttpStatusTranslatorFunction, Throwable, HttpStatus> {
+
+    private final static String MESSAGE = "message123";
+
+    @Test
+    public void testIllegalArgumentExceptionNull() {
+        this.applyAndCheck(
+                new IllegalArgumentException(),
+                HttpStatusCode.BAD_REQUEST
+                        .status()
+        );
+    }
+
+    @Test
+    public void testIllegalArgumentExceptionEmptyMessage() {
+        this.applyAndCheck(
+                new IllegalArgumentException(""),
+                HttpStatusCode.BAD_REQUEST
+                        .status()
+        );
+    }
+
+    @Test
+    public void testIllegalArgumentException() {
+        this.applyAndCheck(
+                new IllegalArgumentException(MESSAGE),
+                HttpStatusCode.BAD_REQUEST
+                        .setMessage(MESSAGE)
+        );
+    }
+
+    @Test
+    public void testIllegalStateExceptionNull() {
+        this.applyAndCheck(
+                new IllegalStateException(),
+                HttpStatusCode.NOT_FOUND.status()
+        );
+    }
+
+    @Test
+    public void testIllegalStateExceptionEmptyMessage() {
+        this.applyAndCheck(
+                new IllegalStateException(""),
+                HttpStatusCode.NOT_FOUND.status()
+        );
+    }
+
+    @Test
+    public void testIllegalStateException() {
+        this.applyAndCheck(
+                new IllegalStateException(MESSAGE),
+                HttpStatusCode.NOT_FOUND
+                        .setMessage(MESSAGE)
+        );
+    }
+
+    private final static HttpStatus STATUS = HttpStatusCode.withCode(999)
+            .setMessage("Hello!");
+
+    @Test
+    public void testHttpResponseHttpServerException() {
+        this.applyAndCheck(
+                new HttpResponseHttpServerException(
+                        STATUS,
+                        HttpResponseHttpServerException.NO_ENTITY
+                ),
+                STATUS
+        );
+    }
+
+    @Test
+    public void testHttpResponseHttpServerExceptionEntityIgnored() {
+        this.applyAndCheck(
+                new HttpResponseHttpServerException(
+                        STATUS,
+                        Optional.of(
+                                HttpEntity.EMPTY.setBodyText("Ignored123")
+                        )
+                ),
+                STATUS
+        );
+    }
+
+    @Test
+    public void testUnsupportedOperationExceptionNull() {
+        this.applyAndCheck(
+                new UnsupportedOperationException(),
+                HttpStatusCode.NOT_IMPLEMENTED
+                        .status()
+        );
+    }
+
+    @Test
+    public void testUnsupportedOperationExceptionEmptyMessage() {
+        this.applyAndCheck(
+                new UnsupportedOperationException(""),
+                HttpStatusCode.NOT_IMPLEMENTED
+                        .status()
+        );
+    }
+
+    @Test
+    public void testUnsupportedOperationException() {
+        this.applyAndCheck(
+                new UnsupportedOperationException(MESSAGE),
+                HttpStatusCode.NOT_IMPLEMENTED
+                        .setMessage(MESSAGE)
+        );
+    }
+
+    @Test
+    public void testExceptionNull() {
+        this.applyAndCheck(
+                new Exception(),
+                HttpStatusCode.INTERNAL_SERVER_ERROR
+                        .status()
+        );
+    }
+
+    @Test
+    public void testExceptionEmptyMessage() {
+        this.applyAndCheck(
+                new Exception(""),
+                HttpStatusCode.INTERNAL_SERVER_ERROR
+                        .status()
+        );
+    }
+
+    @Test
+    public void testException() {
+        this.applyAndCheck(
+                new Exception(MESSAGE),
+                HttpStatusCode.INTERNAL_SERVER_ERROR
+                        .setMessage(MESSAGE)
+        );
+    }
+
+    @Override
+    public ThrowableHttpStatusTranslatorFunction createFunction() {
+        return ThrowableHttpStatusTranslatorFunction.INSTANCE;
+    }
+
+    @Override
+    public Class<ThrowableHttpStatusTranslatorFunction> type() {
+        return ThrowableHttpStatusTranslatorFunction.class;
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/350
- Introduce a Throwable to HttpStatus mapper function

- Closes https://github.com/mP1/walkingkooka-net/issues/349
- map IllegalStateException to 404 NotFound