### PR TITLE
RelativeUrl.parse fragment fix

### DIFF
--- a/src/main/java/walkingkooka/net/RelativeUrl.java
+++ b/src/main/java/walkingkooka/net/RelativeUrl.java
@@ -41,9 +41,20 @@ public final class RelativeUrl extends AbsoluteOrRelativeUrl {
         }
 
         return RelativeUrl.with(
-                UrlPath.parse(uri.getPath()),
-                UrlQueryString.parse(nullToEmpty(uri.getQuery())),
-                UrlFragment.with(nullToEmpty(uri.getFragment())));
+                UrlPath.parse(
+                        uri.getPath()
+                ),
+                UrlQueryString.parse(
+                        nullToEmpty(
+                                uri.getQuery()
+                        )
+                ),
+                UrlFragment.parse(
+                        nullToEmpty(
+                                uri.getFragment()
+                        )
+                )
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/net/RelativeUrlTest.java
+++ b/src/test/java/walkingkooka/net/RelativeUrlTest.java
@@ -40,34 +40,77 @@ public final class RelativeUrlTest extends AbsoluteOrRelativeUrlTestCase<Relativ
 
     @Test
     public void testParseEmptyPath() {
-        final RelativeUrl url = RelativeUrl.parseRelative0("");
+        final String string = "";
+
+        final RelativeUrl url = RelativeUrl.parseRelative0(string);
         this.checkPath(url, UrlPath.EMPTY);
         this.checkQueryString(url, UrlQueryString.EMPTY);
         this.checkFragment(url, UrlFragment.EMPTY);
+
+        this.toStringAndCheck(
+                url,
+                string
+        );
     }
 
     @Test
     public void testParseSlash() {
-        final RelativeUrl url = RelativeUrl.parseRelative0("/");
+        final String string = "/";
+
+        final RelativeUrl url = RelativeUrl.parseRelative0(string);
         this.checkPath(url, UrlPath.parse("/"));
         this.checkQueryString(url, UrlQueryString.EMPTY);
         this.checkFragment(url, UrlFragment.EMPTY);
+
+        this.toStringAndCheck(
+                url,
+                string
+        );
     }
 
     @Test
     public void testParsePathEndingSlash() {
-        final RelativeUrl url = RelativeUrl.parseRelative0("/path/file/");
+        final String string = "/path/file/";
+
+        final RelativeUrl url = RelativeUrl.parseRelative0(string);
         this.checkPath(url, UrlPath.parse("/path/file/"));
         this.checkQueryString(url, UrlQueryString.EMPTY);
         this.checkFragment(url, UrlFragment.EMPTY);
+
+        this.toStringAndCheck(
+                url,
+                string
+        );
     }
 
     @Test
     public void testParsePathQueryStringFragment() {
-        final RelativeUrl url = RelativeUrl.parseRelative0("/path123?query456#fragment789");
+        final String string = "/path123?query456#fragment789";
+
+        final RelativeUrl url = RelativeUrl.parseRelative0(string);
         this.checkPath(url, UrlPath.parse("/path123"));
         this.checkQueryString(url, UrlQueryString.parse("query456"));
         this.checkFragment(url, UrlFragment.with("fragment789"));
+
+        this.toStringAndCheck(
+                url,
+                string
+        );
+    }
+
+    @Test
+    public void testParsePathQueryStringFragmentWithSpace() {
+        final String string = "/path123?query456#fragment+789";
+
+        final RelativeUrl url = RelativeUrl.parseRelative0(string);
+        this.checkPath(url, UrlPath.parse("/path123"));
+        this.checkQueryString(url, UrlQueryString.parse("query456"));
+        this.checkFragment(url, UrlFragment.with("fragment 789"));
+
+        this.toStringAndCheck(
+                url,
+                string
+        );
     }
 
     @Test


### PR DESCRIPTION
- Previously relative url parsing was not decoding the fragment portion, which meant fragments or hashes with spaces were not round-tripping. When calling the UrlFragment.value() a plus-sign was returned where spaces shoudl be.

- Closes https://github.com/mP1/walkingkooka-net/issues/425
- RelativeUrl.parse is not parsing the fragment portion