### PR TITLE
RelativeUrl UrlFragment fragment decoded fix

### DIFF
--- a/src/main/java/walkingkooka/net/RelativeUrl.java
+++ b/src/main/java/walkingkooka/net/RelativeUrl.java
@@ -51,7 +51,7 @@ public final class RelativeUrl extends AbsoluteOrRelativeUrl {
                 ),
                 UrlFragment.parse(
                         nullToEmpty(
-                                uri.getFragment()
+                                uri.getRawFragment() // will be raw not decoded
                         )
                 )
         );


### PR DESCRIPTION
 - Should help prevent exception below when HistoryToken.parse attempts to handle hash including % which was not encoded but just a plain %.

> Uncaught Error: java.lang.IllegalArgumentException: Incomplete % sequence at:52
      createError_0_g$ walkingkooka.spreadsheet.dominokit.App-0.js:3494