### PR TITLE
UrlParameterName "missing query parameter" message

### DIFF
--- a/src/main/java/walkingkooka/net/UrlParameterName.java
+++ b/src/main/java/walkingkooka/net/UrlParameterName.java
@@ -59,7 +59,13 @@ public final class UrlParameterName extends NetName
      * Returns the first value or fails by throwing a {@link IllegalArgumentException} if missing.
      */
     public String firstParameterValueOrFail(final Map<HttpRequestAttribute<?>, ?> parameters) {
-        return this.firstParameterValue(parameters).orElseThrow(() -> new IllegalArgumentException("Missing parameter " + CharSequences.quote(this.value())));
+        return this.firstParameterValue(parameters)
+                .orElseThrow(
+                        () -> new IllegalArgumentException(
+                                "Missing query parameter " +
+                                        CharSequences.quote(this.value())
+                        )
+                );
     }
 
     /**

--- a/src/test/java/walkingkooka/net/UrlParameterNameTest.java
+++ b/src/test/java/walkingkooka/net/UrlParameterNameTest.java
@@ -108,7 +108,7 @@ public final class UrlParameterNameTest implements ClassTesting2<UrlParameterNam
                 IllegalArgumentException.class,
                 () -> this.createObject().firstParameterValueOrFail(Maps.empty())
         );
-        this.checkEquals("Missing parameter \"param-1\"", thrown.getMessage(), "message");
+        this.checkEquals("Missing query parameter \"param-1\"", thrown.getMessage(), "message");
     }
 
     @Test
@@ -117,7 +117,7 @@ public final class UrlParameterNameTest implements ClassTesting2<UrlParameterNam
                 IllegalArgumentException.class,
                 () -> this.createObject().firstParameterValueOrFail(Maps.of(UrlParameterName.with("different"), Lists.of("1a", "2b")))
         );
-        this.checkEquals("Missing parameter \"param-1\"", thrown.getMessage(), "message");
+        this.checkEquals("Missing query parameter \"param-1\"", thrown.getMessage(), "message");
     }
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/376
- UrlParameterName.firstParameterValueOrFail Missing parameter should be Missing query parameter