### PR TITLE
MediaType.testOrFail

### DIFF
--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -529,6 +529,16 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
                 CASE_SENSITIVITY.equals(component, otherComponent);
     }
 
+    /**
+     * Tests if the given {@link MediaType} throwing a {@link IllegalArgumentException} if the test fails.
+     * This useful for handlers wishing to verify the given content-type is compatible with the required type.
+     */
+    public void testOrFail(final MediaType mediaType) {
+        if (false == this.test(mediaType)) {
+            throw new IllegalArgumentException("Requested " + this + " but got " + mediaType);
+        }
+    }
+
     // Header...........................................................................................................
 
     // mime-type COLON sub-mime-type, suffixes already included in sub-mime-type

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -727,6 +727,43 @@ final public class MediaTypeTest extends HeaderWithParametersTestCase<MediaType,
         this.testFalse(MediaType.with(type, "subtype"), MediaType.with(type, "different"));
     }
 
+    // testOrFail.......................................................................................................
+
+    @Test
+    public void testTestOrFailAllWithTextPlain() {
+        MediaType.ALL.testOrFail(MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    public void testTestOrFailTextAnyWithTextPlain() {
+        MediaType.ANY_TEXT.testOrFail(MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    public void testTestOrFailTextPlainWithTextPlain() {
+        MediaType.TEXT_PLAIN.testOrFail(MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    public void testTestOrFailTextPlainWithTextPlainCharset() {
+        MediaType.TEXT_PLAIN.testOrFail(
+                MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8)
+        );
+    }
+
+    @Test
+    public void testTestOrFailTextPlainWithTextRichTextFails() {
+        final IllegalArgumentException thrown = assertThrows(
+                IllegalArgumentException.class,
+                () -> MediaType.TEXT_PLAIN.testOrFail(MediaType.TEXT_RICHTEXT)
+        );
+
+        this.checkEquals(
+                "Requested text/plain but got text/richtext",
+                thrown.getMessage()
+        );
+    }
+
     // toHeaderText........................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/525
- MediaType.testOrFail - if test fails throws IllegalArgumentException("Required " + this + " got " + parameter );