### PR TITLE
HeaderHandler.parseValue fail message prefixed by header name

### DIFF
--- a/src/main/java/walkingkooka/net/header/AbsoluteUrlHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/AbsoluteUrlHeaderHandler.java
@@ -40,16 +40,16 @@ final class AbsoluteUrlHeaderHandler extends NonStringHeaderHandler<AbsoluteUrl>
     }
 
     @Override
-    AbsoluteUrl parse0(final String text, final Name name) {
+    AbsoluteUrl parse0(final String text) {
         return Url.parseAbsolute(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof AbsoluteUrl,
-                AbsoluteUrl.class,
-                name);
+                AbsoluteUrl.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/AcceptCharsetHeaderHandler.java
@@ -38,16 +38,16 @@ final class AcceptCharsetHeaderHandler extends NonStringHeaderHandler<AcceptChar
     }
 
     @Override
-    AcceptCharset parse0(final String text, final Name name) {
+    AcceptCharset parse0(final String text) {
         return AcceptCharset.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof AcceptCharset,
-                AcceptCharset.class,
-                name);
+                AcceptCharset.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptEncodingHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/AcceptEncodingHeaderHandler.java
@@ -48,16 +48,16 @@ final class AcceptEncodingHeaderHandler extends NonStringHeaderHandler<AcceptEnc
     }
 
     @Override
-    AcceptEncoding parse0(final String text, final Name name) {
+    AcceptEncoding parse0(final String text) {
         return AcceptEncodingHeaderParser.parseAcceptEncoding(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof AcceptEncoding,
-                AcceptEncoding.class,
-                name);
+                AcceptEncoding.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptEncodingHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/AcceptEncodingHeaderParser.java
@@ -98,7 +98,9 @@ final class AcceptEncodingHeaderParser extends HeaderParserWithParameters<Accept
 
     @Override
     AcceptEncodingValue value() {
-        return AcceptEncodingValue.with(this.token(RFC2045TOKEN));
+        return AcceptEncodingValue.with(
+                this.rfc2045Token()
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptEncodingValueHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/AcceptEncodingValueHeaderParser.java
@@ -93,7 +93,9 @@ final class AcceptEncodingValueHeaderParser extends HeaderParserWithParameters<A
 
     @Override
     AcceptEncodingValue value() {
-        return AcceptEncodingValue.with(this.token(RFC2045TOKEN));
+        return AcceptEncodingValue.with(
+                this.rfc2045Token()
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/AcceptHeaderHandler.java
@@ -37,16 +37,16 @@ final class AcceptHeaderHandler extends NonStringHeaderHandler<Accept> {
     }
 
     @Override
-    Accept parse0(final String text, final Name name) {
+    Accept parse0(final String text) {
         return Accept.with(MediaType.parseList(text));
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof Accept,
-                Accept.class,
-                name);
+                Accept.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/AcceptLanguageHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/AcceptLanguageHeaderHandler.java
@@ -44,16 +44,16 @@ final class AcceptLanguageHeaderHandler extends NonStringHeaderHandler<AcceptLan
     }
 
     @Override
-    AcceptLanguage parse0(final String text, final Name name) {
+    AcceptLanguage parse0(final String text) {
         return AcceptLanguageHeaderParser.parseAcceptLanguage(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof AcceptLanguage,
-                AcceptLanguage.class,
-                name);
+                AcceptLanguage.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderHandler.java
@@ -43,13 +43,13 @@ final class CacheControlDirectiveExtensionHeaderHandler extends NonStringHeaderH
      * Try parsing as a {@link Long} and then {@link String}
      */
     @Override
-    Object parse0(final String text, final Name name) throws HeaderException {
+    Object parse0(final String text) throws HeaderException {
         Object value;
 
         try {
-            value = LONG.parse(text, name);
+            value = LONG.parse(text);
         } catch (final HeaderException cause) {
-            value = QUOTED_UNQUOTED_STRING.parse(text, name);
+            value = QUOTED_UNQUOTED_STRING.parse(text);
         }
 
         return value;
@@ -59,11 +59,11 @@ final class CacheControlDirectiveExtensionHeaderHandler extends NonStringHeaderH
      * Try checking as a {@link Long} and then {@link String}
      */
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         try {
-            LONG.check(value, name);
+            LONG.check(value);
         } catch (final HeaderException cause) {
-            QUOTED_UNQUOTED_STRING.check(value, name);
+            QUOTED_UNQUOTED_STRING.check(value);
         }
     }
 

--- a/src/main/java/walkingkooka/net/header/CacheControlDirectiveName.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirectiveName.java
@@ -206,7 +206,7 @@ public final class CacheControlDirectiveName<V> extends HeaderName2<Optional<V>>
 
     @Override
     public Optional<V> parse(final String text) {
-        return Optional.of(this.handler.parse(text, this));
+        return Optional.of(this.handler.parse(text));
     }
 
     boolean requiresParameter() {

--- a/src/main/java/walkingkooka/net/header/CacheControlDirectiveNameParameter.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlDirectiveNameParameter.java
@@ -31,7 +31,7 @@ enum CacheControlDirectiveNameParameter {
         @Override
         <T> Optional<T> check0(final Optional<T> value, final CacheControlDirectiveName<T> name) {
             if (value.isPresent()) {
-                name.handler.check(value.get(), name);
+                name.handler.check(value.get());
             } else {
                 fail("Directive " + name + " missing required parameter.");
             }
@@ -41,7 +41,7 @@ enum CacheControlDirectiveNameParameter {
     OPTIONAL {
         @Override
         <T> Optional<T> check0(final Optional<T> value, final CacheControlDirectiveName<T> name) {
-            value.ifPresent((v) -> name.handler.check(v, name));
+            value.ifPresent((v) -> name.handler.check(v));
 
             return value;
         }

--- a/src/main/java/walkingkooka/net/header/CacheControlHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlHeaderHandler.java
@@ -37,16 +37,16 @@ final class CacheControlHeaderHandler extends NonStringHeaderHandler<CacheContro
     }
 
     @Override
-    CacheControl parse0(final String text, final Name name) {
+    CacheControl parse0(final String text) {
         return CacheControlHeaderParser.parseCacheControl(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof CacheControl,
-                CacheControl.class,
-                name);
+                CacheControl.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/CacheControlHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/CacheControlHeaderParser.java
@@ -114,7 +114,9 @@ final class CacheControlHeaderParser extends HeaderParser {
     void token() {
         if (this.requireDirectiveName) {
             this.requireDirectiveName = false;
-            this.directiveName = CacheControlDirectiveName.with(this.token(RFC2045TOKEN));
+            this.directiveName = CacheControlDirectiveName.with(
+                    this.rfc2045Token()
+            );
             this.parameterValue = Optional.empty();
         } else {
             if (!this.expectsParameterValue) {

--- a/src/main/java/walkingkooka/net/header/CharsetNameHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/CharsetNameHeaderHandler.java
@@ -38,16 +38,16 @@ final class CharsetNameHeaderHandler extends NonStringHeaderHandler<CharsetName>
     }
 
     @Override
-    CharsetName parse0(final String text, final Name name) {
+    CharsetName parse0(final String text) {
         return CharsetName.with(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof CharsetName,
-                CharsetName.class,
-                name);
+                CharsetName.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ClientCookieListHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ClientCookieListHeaderHandler.java
@@ -39,16 +39,17 @@ final class ClientCookieListHeaderHandler extends NonStringHeaderHandler<List<Cl
     }
 
     @Override
-    List<ClientCookie> parse0(final String text, final Name name) {
+    List<ClientCookie> parse0(final String text) {
         return Cookie.parseClientHeader(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
-        this.checkListOfType(value,
+    void checkNonNull(final Object value) {
+        this.checkListOfType(
+                value,
                 (v) -> v instanceof ClientCookie,
-                ClientCookie.class,
-                name);
+                ClientCookie.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentDispositionFileNameEncodedHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionFileNameEncodedHeaderHandler.java
@@ -38,16 +38,16 @@ final class ContentDispositionFileNameEncodedHeaderHandler extends NonStringHead
     }
 
     @Override
-    ContentDispositionFileName parse0(final String text, final Name name) {
-        return ContentDispositionFileName.encoded(HeaderHandler.encodedText().parse(text, name));
+    ContentDispositionFileName parse0(final String text) {
+        return ContentDispositionFileName.encoded(HeaderHandler.encodedText().parse(text));
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof ContentDispositionFileNameEncoded,
-                ContentDispositionFileNameEncoded.class,
-                name);
+                ContentDispositionFileNameEncoded.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentDispositionFileNameNotEncoded.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionFileNameNotEncoded.java
@@ -31,7 +31,7 @@ final class ContentDispositionFileNameNotEncoded extends ContentDispositionFileN
      * Factory that creates a {@link ContentDispositionFileNameNotEncoded}.
      */
     static ContentDispositionFileNameNotEncoded with(final String name) {
-        CharPredicates.failIfNullOrEmptyOrFalse(name, "name", FILENAME);
+        CharPredicates.failIfNullOrEmptyOrFalse(name, "filename", FILENAME);
 
         return new ContentDispositionFileNameNotEncoded(name);
     }

--- a/src/main/java/walkingkooka/net/header/ContentDispositionFileNameNotEncodedHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionFileNameNotEncodedHeaderHandler.java
@@ -39,16 +39,16 @@ final class ContentDispositionFileNameNotEncodedHeaderHandler extends NonStringH
     }
 
     @Override
-    ContentDispositionFileName parse0(final String text, final Name name) {
-        return ContentDispositionFileName.notEncoded(QUOTED_UNQUOTED_STRING.parse(text, name));
+    ContentDispositionFileName parse0(final String text) {
+        return ContentDispositionFileName.notEncoded(QUOTED_UNQUOTED_STRING.parse(text));
     }
 
     @Override
-    void check0(Object value, Name name) {
+    void checkNonNull(Object value) {
         this.checkType(value,
                 v -> v instanceof ContentDispositionFileNameNotEncoded,
-                ContentDispositionFileNameNotEncoded.class,
-                name);
+                ContentDispositionFileNameNotEncoded.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentDispositionHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionHeaderHandler.java
@@ -38,16 +38,16 @@ final class ContentDispositionHeaderHandler extends NonStringHeaderHandler<Conte
     }
 
     @Override
-    ContentDisposition parse0(final String text, final Name name) {
+    ContentDisposition parse0(final String text) {
         return ContentDisposition.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof ContentDisposition,
-                ContentDisposition.class,
-                name);
+                ContentDisposition.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentEncodingHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentEncodingHeaderHandler.java
@@ -48,16 +48,16 @@ final class ContentEncodingHeaderHandler extends NonStringHeaderHandler<ContentE
     }
 
     @Override
-    ContentEncoding parse0(final String text, final Name name) {
+    ContentEncoding parse0(final String text) {
         return ContentEncodingHeaderParser.parseContentEncoding(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof ContentEncoding,
-                ContentEncoding.class,
-                name);
+                ContentEncoding.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentEncodingHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/ContentEncodingHeaderParser.java
@@ -95,7 +95,11 @@ final class ContentEncodingHeaderParser extends HeaderParser {
 
     @Override
     void token() {
-        this.encodings.add(Encoding.with(this.token(RFC2045TOKEN)));
+        this.encodings.add(
+                Encoding.with(
+                        this.rfc2045Token()
+                )
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentLanguageHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentLanguageHeaderHandler.java
@@ -42,16 +42,16 @@ final class ContentLanguageHeaderHandler extends NonStringHeaderHandler<ContentL
     }
 
     @Override
-    ContentLanguage parse0(final String text, final Name name) {
+    ContentLanguage parse0(final String text) {
         return ContentLanguageHeaderParser.parseContentLanguage(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof ContentLanguage,
-                ContentLanguage.class,
-                name);
+                ContentLanguage.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentLanguageHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/ContentLanguageHeaderParser.java
@@ -93,7 +93,11 @@ final class ContentLanguageHeaderParser extends HeaderParser {
 
     @Override
     void token() {
-        this.languages.add(LanguageName.with(this.token(RFC2045TOKEN)));
+        this.languages.add(
+                LanguageName.with(
+                        this.rfc2045Token()
+                )
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ContentRangeHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ContentRangeHeaderHandler.java
@@ -37,16 +37,16 @@ final class ContentRangeHeaderHandler extends NonStringHeaderHandler<ContentRang
     }
 
     @Override
-    ContentRange parse0(final String text, final Name name) {
+    ContentRange parse0(final String text) {
         return ContentRange.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof ContentRange,
-                ContentRange.class,
-                name);
+                ContentRange.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ETagHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ETagHeaderHandler.java
@@ -39,16 +39,16 @@ final class ETagHeaderHandler extends NonStringHeaderHandler<ETag> {
     }
 
     @Override
-    ETag parse0(final String text, final Name name) {
+    ETag parse0(final String text) {
         return ETag.parseOne(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof ETag,
-                ETag.class,
-                name);
+                ETag.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ETagListHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ETagListHeaderHandler.java
@@ -39,16 +39,16 @@ final class ETagListHeaderHandler extends NonStringHeaderHandler<List<ETag>> {
     }
 
     @Override
-    List<ETag> parse0(final String text, final Name name) {
+    List<ETag> parse0(final String text) {
         return ETag.parseList(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkListOfType(value,
                 v -> v instanceof ETag,
-                ETag.class,
-                name);
+                ETag.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/EmailAddressHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/EmailAddressHeaderHandler.java
@@ -43,20 +43,20 @@ final class EmailAddressHeaderHandler extends NonStringHeaderHandler<EmailAddres
     }
 
     @Override
-    EmailAddress parse0(final String text, final Name name) {
+    EmailAddress parse0(final String text) {
         final Optional<EmailAddress> emailAddress = EmailAddress.tryParse(text);
         if (!emailAddress.isPresent()) {
-            throw new IllegalArgumentException(name + " contains invalid email " + CharSequences.quote(text));
+            throw new IllegalArgumentException("Invalid email " + CharSequences.quote(text));
         }
         return emailAddress.get();
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof EmailAddress,
-                EmailAddress.class,
-                name);
+                EmailAddress.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/EncodedTextHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/EncodedTextHeaderHandler.java
@@ -38,16 +38,16 @@ final class EncodedTextHeaderHandler extends NonStringHeaderHandler<EncodedText>
     }
 
     @Override
-    EncodedText parse0(final String text, final Name name) {
-        return EncodedTextHeaderHandlerHeaderParser.parseEncodedText(text, name.value());
+    EncodedText parse0(final String text) {
+        return EncodedTextHeaderHandlerHeaderParser.parseEncodedText(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof EncodedText,
-                EncodedText.class,
-                name);
+                EncodedText.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/EncodedTextHeaderHandlerHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/EncodedTextHeaderHandlerHeaderParser.java
@@ -22,20 +22,19 @@ package walkingkooka.net.header;
  */
 final class EncodedTextHeaderHandlerHeaderParser extends HeaderParser {
 
-    static EncodedText parseEncodedText(final String text, final String label) {
-        final EncodedTextHeaderHandlerHeaderParser parser = new EncodedTextHeaderHandlerHeaderParser(text, label);
+    static EncodedText parseEncodedText(final String text) {
+        final EncodedTextHeaderHandlerHeaderParser parser = new EncodedTextHeaderHandlerHeaderParser(text);
         parser.parse();
         return parser.encodedText;
     }
 
-    static EncodedTextHeaderHandlerHeaderParser with(final String text, final String label) {
-        return new EncodedTextHeaderHandlerHeaderParser(text, label);
+    static EncodedTextHeaderHandlerHeaderParser with(final String text) {
+        return new EncodedTextHeaderHandlerHeaderParser(text);
     }
 
     // @VisibleForTesting
-    private EncodedTextHeaderHandlerHeaderParser(final String text, final String label) {
+    private EncodedTextHeaderHandlerHeaderParser(final String text) {
         super(text);
-        this.label = label;
     }
 
     @Override
@@ -90,10 +89,8 @@ final class EncodedTextHeaderHandlerHeaderParser extends HeaderParser {
 
     @Override
     void missingValue() {
-        this.failMissingValue(this.label);
+        this.failMissingValue("text");
     }
-
-    private final String label;
 
     private EncodedText encodedText;
 }

--- a/src/main/java/walkingkooka/net/header/HeaderParameterName.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParameterName.java
@@ -52,7 +52,7 @@ abstract class HeaderParameterName<V> extends HeaderName2<V> {
     public final V parse(final String text) {
         Objects.requireNonNull(text, "text");
 
-        return this.handler.parse(text, this);
+        return this.handler.parse(text);
     }
 
     /**
@@ -60,7 +60,7 @@ abstract class HeaderParameterName<V> extends HeaderName2<V> {
      */
     @Override
     public final V check(final Object header) {
-        return this.handler.check(header, this);
+        return this.handler.check(header);
     }
 
     final HeaderHandler<V> handler;

--- a/src/main/java/walkingkooka/net/header/HeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/HeaderParser.java
@@ -509,6 +509,14 @@ abstract class HeaderParser {
         return this.text.substring(start, this.position);
     }
 
+    final String rfc2045Token() {
+        final String token = this.token(RFC2045TOKEN);
+        if (token.isEmpty()) {
+            this.failInvalidCharacter();
+        }
+        return token;
+    }
+
     // whitespace.................................................................................................
 
     /**

--- a/src/main/java/walkingkooka/net/header/HttpHeaderName.java
+++ b/src/main/java/walkingkooka/net/header/HttpHeaderName.java
@@ -25,6 +25,7 @@ import walkingkooka.net.RelativeUrl;
 import walkingkooka.net.Url;
 import walkingkooka.net.email.EmailAddress;
 import walkingkooka.net.http.HasHeaders;
+import walkingkooka.net.http.HttpEntity;
 import walkingkooka.net.http.HttpMethod;
 import walkingkooka.net.http.server.HttpRequest;
 import walkingkooka.net.http.server.HttpRequestAttribute;
@@ -780,7 +781,7 @@ final public class HttpHeaderName<T> extends HeaderName2<T>
      */
     @Override
     public T check(final Object header) {
-        return this.handler.check(header, this);
+        return this.handler.check(header);
     }
 
     /**
@@ -813,7 +814,18 @@ final public class HttpHeaderName<T> extends HeaderName2<T>
     public T parse(final String value) {
         Objects.requireNonNull(value, "value");
 
-        return this.handler.parse(value, this);
+        // Accept: Invalid character '?' at 1 in " ?"
+        try {
+            return this.handler.parse(
+                    value
+            );
+        } catch (final Exception cause) {
+            // Accept: Invalid character '?' at 1 in " ?"
+            throw new HeaderException(
+                    this.name + HttpEntity.HEADER_NAME_SEPARATOR + " " + cause.getMessage(),
+                    cause
+            );
+        }
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/HttpHeaderNameListHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/HttpHeaderNameListHeaderHandler.java
@@ -42,18 +42,18 @@ final class HttpHeaderNameListHeaderHandler extends NonStringHeaderHandler<List<
     }
 
     @Override
-    List<HttpHeaderName<?>> parse0(final String text, final Name name) {
+    List<HttpHeaderName<?>> parse0(final String text) {
         return Arrays.stream(text.split(","))
                 .map(m -> Cast.<HttpHeaderName<?>>to(HttpHeaderName.with(m.trim())))
                 .collect(Collectors.toList());
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkListOfType(value,
                 v -> v instanceof HttpHeaderName,
-                HttpHeaderName.class,
-                name);
+                HttpHeaderName.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/HttpMethodHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/HttpMethodHeaderHandler.java
@@ -38,16 +38,16 @@ final class HttpMethodHeaderHandler extends NonStringHeaderHandler<HttpMethod> {
     }
 
     @Override
-    HttpMethod parse0(final String text, final Name name) {
+    HttpMethod parse0(final String text) {
         return HttpMethod.with(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof HttpMethod,
-                HttpMethod.class,
-                name);
+                HttpMethod.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/HttpMethodListHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/HttpMethodListHeaderHandler.java
@@ -42,18 +42,19 @@ final class HttpMethodListHeaderHandler extends NonStringHeaderHandler<List<Http
     }
 
     @Override
-    List<HttpMethod> parse0(final String text, final Name name) {
+    List<HttpMethod> parse0(final String text) {
         return Arrays.stream(text.split(","))
                 .map(m -> HttpMethod.with(m.trim()))
                 .collect(Collectors.toList());
     }
 
     @Override
-    void check0(final Object value, final Name name) {
-        this.checkListOfType(value,
+    void checkNonNull(final Object value) {
+        this.checkListOfType(
+                value,
                 v -> v instanceof HttpMethod,
-                HttpMethod.class,
-                name);
+                HttpMethod.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/IfRange.java
+++ b/src/main/java/walkingkooka/net/header/IfRange.java
@@ -74,8 +74,7 @@ public abstract class IfRange<T> implements Header, Value<T> {
      */
     public static IfRange<?> parse(final String text) {
         return IfRangeHeaderHandler.INSTANCE.parse(
-                CharSequences.failIfNullOrEmpty(text, "text"),
-                HEADER_NAME
+                CharSequences.failIfNullOrEmpty(text, "text")
         );
     }
 

--- a/src/main/java/walkingkooka/net/header/IfRangeHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/IfRangeHeaderHandler.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.header;
 
 import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
 
 import java.time.LocalDateTime;
 
@@ -39,12 +40,23 @@ final class IfRangeHeaderHandler extends NonStringHeaderHandler<IfRange<?>> {
     }
 
     @Override
-    IfRange<?> parse0(final String text, final Name name) {
+    IfRange<?> parse0(final String text) {
         IfRange<?> parsed;
         try {
             parsed = IfRangeETag.with(ETag.parseOne(text));
         } catch (final HeaderException mustBeLastModified) {
-            parsed = IfRangeLastModified.with(DATE_TIME.parse(text, HttpHeaderName.IF_RANGE));
+            final LocalDateTime date;
+
+            try {
+                date = DATE_TIME.parse(
+                        text
+                );
+            } catch (final HeaderException cause) {
+                throw new IllegalArgumentException("Invalid date in " + CharSequences.quoteAndEscape(text));
+            }
+            parsed = IfRangeLastModified.with(
+                    date
+            );
         }
         return parsed;
     }
@@ -52,11 +64,11 @@ final class IfRangeHeaderHandler extends NonStringHeaderHandler<IfRange<?>> {
     final static HeaderHandler<LocalDateTime> DATE_TIME = HeaderHandler.localDateTime();
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof IfRange,
-                IfRange.class,
-                name);
+                IfRange.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/LanguageNameHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/LanguageNameHeaderHandler.java
@@ -37,16 +37,16 @@ final class LanguageNameHeaderHandler extends NonStringHeaderHandler<LanguageNam
     }
 
     @Override
-    LanguageName parse0(final String value, final Name name) {
+    LanguageName parse0(final String value) {
         return LanguageName.with(value);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof LanguageName,
-                LanguageName.class,
-                name);
+                LanguageName.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/LinkHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/LinkHeaderHandler.java
@@ -39,16 +39,16 @@ final class LinkHeaderHandler extends NonStringHeaderHandler<List<Link>> {
     }
 
     @Override
-    List<Link> parse0(final String text, final Name name) {
+    List<Link> parse0(final String text) {
         return LinkHeaderParser.parseLink(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkListOfType(value,
                 v -> v instanceof Link,
-                Link.class,
-                name);
+                Link.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/LinkRelationHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/LinkRelationHeaderHandler.java
@@ -39,16 +39,17 @@ final class LinkRelationHeaderHandler extends NonStringHeaderHandler<List<LinkRe
     }
 
     @Override
-    List<LinkRelation<?>> parse0(final String text, final Name name) {
+    List<LinkRelation<?>> parse0(final String text) {
         return LinkRelationHeaderParser.parseLinkRelationList(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
-        this.checkListOfType(value,
+    void checkNonNull(final Object value) {
+        this.checkListOfType(
+                value,
                 v -> v instanceof LinkRelation,
-                LinkRelation.class,
-                name);
+                LinkRelation.class
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/LocalDateTimeHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/LocalDateTimeHeaderHandler.java
@@ -18,10 +18,12 @@
 package walkingkooka.net.header;
 
 import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,16 +59,23 @@ final class LocalDateTimeHeaderHandler extends NonStringHeaderHandler<LocalDateT
     }
 
     @Override
-    LocalDateTime parse0(final String text, final Name name) {
-        return LocalDateTime.parse(text, FORMATTER);
+    LocalDateTime parse0(final String text) {
+        try {
+            return LocalDateTime.parse(
+                    text,
+                    FORMATTER
+            );
+        } catch (final DateTimeParseException cause) {
+            throw new HeaderException("Invalid date in " + CharSequences.quoteAndEscape(text));
+        }
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof LocalDateTime,
-                LocalDateTime.class,
-                name);
+                LocalDateTime.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/LongHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/LongHeaderHandler.java
@@ -38,7 +38,7 @@ final class LongHeaderHandler extends NonStringHeaderHandler<Long> {
     }
 
     @Override
-    Long parse0(final String text, final Name name) {
+    Long parse0(final String text) {
         final String trimmed = text.trim();
         CharSequences.failIfNullOrEmpty(trimmed, "text");
 
@@ -50,11 +50,11 @@ final class LongHeaderHandler extends NonStringHeaderHandler<Long> {
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof Long,
-                Long.class,
-                name);
+                Long.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/MediaTypeBoundary.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeBoundary.java
@@ -125,7 +125,7 @@ public final class MediaTypeBoundary implements Value<String>,
      * Parses the text into a {@link MediaTypeBoundary}.
      */
     public static MediaTypeBoundary parse(final String value) {
-        return MediaTypeBoundaryHeaderHandler.INSTANCE.parse(value, MediaTypeParameterName.BOUNDARY);
+        return MediaTypeBoundaryHeaderHandler.INSTANCE.parse(value);
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/MediaTypeBoundaryHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeBoundaryHeaderHandler.java
@@ -40,8 +40,8 @@ final class MediaTypeBoundaryHeaderHandler extends NonStringHeaderHandler<MediaT
     }
 
     @Override
-    MediaTypeBoundary parse0(final String text, final Name name) {
-        return MediaTypeBoundary.with(STRING_PARSER.parse(text, name));
+    MediaTypeBoundary parse0(final String text) {
+        return MediaTypeBoundary.with(STRING_PARSER.parse(text));
     }
 
     private final HeaderHandler<String> STRING_PARSER = HeaderHandler.quotedUnquotedString(MediaTypeBoundary.QUOTED_CHARACTER_PREDICATE,
@@ -49,11 +49,11 @@ final class MediaTypeBoundaryHeaderHandler extends NonStringHeaderHandler<MediaT
             MediaTypeBoundary.UNQUOTED_CHARACTER_PREDICATE);
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof MediaTypeBoundary,
-                MediaTypeBoundary.class,
-                name);
+                MediaTypeBoundary.class
+        );
     }
 
     /**

--- a/src/main/java/walkingkooka/net/header/MediaTypeHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeHeaderHandler.java
@@ -37,16 +37,16 @@ final class MediaTypeHeaderHandler extends NonStringHeaderHandler<MediaType> {
     }
 
     @Override
-    MediaType parse0(final String text, final Name name) {
+    MediaType parse0(final String text) {
         return MediaType.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof MediaType,
-                MediaType.class,
-                name);
+                MediaType.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/OffsetDateTimeHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/OffsetDateTimeHeaderHandler.java
@@ -19,6 +19,7 @@ package walkingkooka.net.header;
 
 import walkingkooka.naming.Name;
 import walkingkooka.predicate.character.CharPredicates;
+import walkingkooka.text.CharSequences;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -59,18 +60,22 @@ final class OffsetDateTimeHeaderHandler extends NonStringHeaderHandler<OffsetDat
     }
 
     @Override
-    OffsetDateTime parse0(final String text, final Name name) {
-        return OffsetDateTime.parse(
-                QUOTED_STRING.parse(text, name),
-                FORMATTER);
+    OffsetDateTime parse0(final String text) {
+        try {
+            return OffsetDateTime.parse(
+                    QUOTED_STRING.parse(text),
+                    FORMATTER);
+        } catch (final IllegalArgumentException cause) {
+            throw new IllegalArgumentException("Invalid date in " + CharSequences.quoteAndEscape(text));
+        }
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof OffsetDateTime,
-                OffsetDateTime.class,
-                name);
+                OffsetDateTime.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/QualityFactorHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/QualityFactorHeaderHandler.java
@@ -18,6 +18,7 @@
 package walkingkooka.net.header;
 
 import walkingkooka.naming.Name;
+import walkingkooka.text.CharSequences;
 
 /**
  * A {@link HeaderHandler} that parses a header text into a quality weights and verifies the value is within the
@@ -38,16 +39,23 @@ final class QualityFactorHeaderHandler extends NonStringHeaderHandler<Float> {
     }
 
     @Override
-    Float parse0(final String text, final Name name) {
-        return this.checkValue(Float.parseFloat(text.trim()));
+    Float parse0(final String text) {
+        final String trimmed = text.trim();
+        CharSequences.failIfNullOrEmpty(trimmed, "text");
+
+        try {
+            return Float.parseFloat(trimmed);
+        } catch (final NumberFormatException cause) {
+            throw new IllegalArgumentException("Invalid number in " + CharSequences.quoteAndEscape(text));
+        }
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof Float,
-                Float.class,
-                name);
+                Float.class
+        );
         this.checkValue((Float) value);
     }
 

--- a/src/main/java/walkingkooka/net/header/QuotedStringHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/QuotedStringHeaderHandler.java
@@ -21,6 +21,7 @@ import walkingkooka.InvalidCharacterException;
 import walkingkooka.naming.Name;
 import walkingkooka.predicate.character.CharPredicate;
 import walkingkooka.text.Ascii;
+import walkingkooka.text.CharSequences;
 
 /**
  * A {@link HeaderHandler} that handles string values in quotes with possible backslash escaping.
@@ -45,7 +46,12 @@ final class QuotedStringHeaderHandler extends QuotedOrUnquotedStringHeaderHandle
     }
 
     @Override
-    String parse0(final String text, final Name name) {
+    String parse0(final String text) {
+        CharSequences.failIfNullOrEmpty(
+                text,
+                "text"
+        );
+
         final int length = text.length();
 
         final int last = length - 1;

--- a/src/main/java/walkingkooka/net/header/QuotedUnquotedStringHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/QuotedUnquotedStringHeaderHandler.java
@@ -52,11 +52,11 @@ final class QuotedUnquotedStringHeaderHandler extends StringHeaderHandler {
      * If the text begins witn a double quote and then selects either the quoted or unquoted handler to parse.
      */
     @Override
-    String parse0(final String text, final Name name) {
+    String parse0(final String text) {
         final HeaderHandler<String> handler = text.isEmpty() || text.charAt(0) != '"' ?
                 this.unquoted :
                 this.quoted;
-        return handler.parse(text, name);
+        return handler.parse(text);
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/RangeHeaderHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/RangeHeaderHeaderHandler.java
@@ -46,16 +46,16 @@ final class RangeHeaderHeaderHandler extends NonStringHeaderHandler<RangeHeader>
     }
 
     @Override
-    RangeHeader parse0(final String text, final Name name) {
+    RangeHeader parse0(final String text) {
         return RangeHeader.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof RangeHeader,
-                RangeHeader.class,
-                name);
+                RangeHeader.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/RangeHeaderUnitHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/RangeHeaderUnitHeaderHandler.java
@@ -43,16 +43,16 @@ final class RangeHeaderUnitHeaderHandler extends NonStringHeaderHandler<RangeHea
     }
 
     @Override
-    RangeHeaderUnit parse0(final String text, final Name name) {
+    RangeHeaderUnit parse0(final String text) {
         return RangeHeaderUnit.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof RangeHeaderUnit,
-                RangeHeaderUnit.class,
-                name);
+                RangeHeaderUnit.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/RelativeUrlHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/RelativeUrlHeaderHandler.java
@@ -40,16 +40,16 @@ final class RelativeUrlHeaderHandler extends NonStringHeaderHandler<RelativeUrl>
     }
 
     @Override
-    RelativeUrl parse0(final String text, final Name name) {
+    RelativeUrl parse0(final String text) {
         return Url.parseRelative(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof RelativeUrl,
-                RelativeUrl.class,
-                name);
+                RelativeUrl.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/ServerCookieHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/ServerCookieHeaderHandler.java
@@ -37,16 +37,16 @@ final class ServerCookieHeaderHandler extends NonStringHeaderHandler<ServerCooki
     }
 
     @Override
-    ServerCookie parse0(final String text, final Name name) {
+    ServerCookie parse0(final String text) {
         return Cookie.parseServerHeader(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof ServerCookie,
-                ServerCookie.class,
-                name);
+                ServerCookie.class
+        );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/header/StringHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/StringHeaderHandler.java
@@ -18,7 +18,6 @@
 package walkingkooka.net.header;
 
 import walkingkooka.Cast;
-import walkingkooka.naming.Name;
 
 /**
  * A {@link HeaderHandler} that handles string values.
@@ -32,11 +31,11 @@ abstract class StringHeaderHandler extends HeaderHandler<String> {
         super();
     }
 
-    @Override final void check0(final Object value, final Name name) {
+    @Override final void checkNonNull(final Object value) {
         this.checkType(value,
                 (v) -> v instanceof String,
-                String.class,
-                name);
+                String.class
+        );
     }
 
     @Override final HttpHeaderName<String> httpHeaderNameCast(final HttpHeaderName<?> headerName) {

--- a/src/main/java/walkingkooka/net/header/UnalteredStringHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/UnalteredStringHeaderHandler.java
@@ -37,7 +37,7 @@ final class UnalteredStringHeaderHandler extends StringHeaderHandler {
     }
 
     @Override
-    String parse0(final String text, final Name name) {
+    String parse0(final String text) {
         return text;
     }
 

--- a/src/main/java/walkingkooka/net/header/UnquotedStringHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/UnquotedStringHeaderHandler.java
@@ -41,7 +41,7 @@ final class UnquotedStringHeaderHandler extends QuotedOrUnquotedStringHeaderHand
     }
 
     @Override
-    String parse0(final String text, final Name name) {
+    String parse0(final String text) {
         this.checkText(text);
         return text;
     }

--- a/src/main/java/walkingkooka/net/header/UrlHeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/UrlHeaderHandler.java
@@ -39,16 +39,16 @@ final class UrlHeaderHandler extends NonStringHeaderHandler<Url> {
     }
 
     @Override
-    Url parse0(final String text, final Name name) {
+    Url parse0(final String text) {
         return Url.parse(text);
     }
 
     @Override
-    void check0(final Object value, final Name name) {
+    void checkNonNull(final Object value) {
         this.checkType(value,
                 v -> v instanceof Url,
-                Url.class,
-                name);
+                Url.class
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptCharsetHeaderParserTest.java
@@ -433,8 +433,10 @@ public final class AcceptCharsetHeaderParserTest extends HeaderParserWithParamet
 
     @Test
     public void testQInvalidValueFails() {
-        this.parseStringFails("utf-8; q=X",
-                "Failed to convert \"q\" value \"X\", message: For input string: \"X\"");
+        this.parseStringFails(
+                "utf-8; q=X",
+                "Invalid number in \"X\""
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptEncodingHeaderHandlerTest.java
@@ -45,7 +45,7 @@ public final class AcceptEncodingHeaderHandlerTest extends NonStringHeaderHandle
 
     @Test
     public void testCheckEmptyListFails() {
-        assertThrows(HeaderException.class, () -> AcceptEncodingHeaderHandler.INSTANCE.check(Lists.empty(), HttpHeaderName.ACCEPT_ENCODING));
+        assertThrows(HeaderException.class, () -> AcceptEncodingHeaderHandler.INSTANCE.check(Lists.empty()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/AcceptLanguageOrAcceptLanguageValueHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/AcceptLanguageOrAcceptLanguageValueHeaderParserTestCase.java
@@ -56,8 +56,10 @@ public abstract class AcceptLanguageOrAcceptLanguageValueHeaderParserTestCase<P 
 
     @Test
     public final void testWildcardQWeightInvalidValueFails() {
-        this.parseStringFails("*; q=ABC",
-                "Failed to convert \"q\" value \"ABC\", message: For input string: \"ABC\"");
+        this.parseStringFails(
+                "*; q=ABC",
+                "Invalid number in \"ABC\""
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/CacheControlDirectiveExtensionHeaderHandlerTest.java
@@ -27,12 +27,12 @@ public final class CacheControlDirectiveExtensionHeaderHandlerTest extends
 
     @Test
     public void testCheckLong() {
-        CacheControlDirectiveExtensionHeaderHandler.INSTANCE.check(123L, this.name());
+        CacheControlDirectiveExtensionHeaderHandler.INSTANCE.check(123L);
     }
 
     @Test
     public void testCheckString() {
-        CacheControlDirectiveExtensionHeaderHandler.INSTANCE.check("abc123", this.name());
+        CacheControlDirectiveExtensionHeaderHandler.INSTANCE.check("abc123");
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentDispositionHeaderParserTest.java
@@ -413,8 +413,10 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
 
     @Test
     public void testCreationDateInvalidFails() {
-        this.parseStringFails("V; creation-date=123",
-                "Failed to convert \"creation-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
+        this.parseStringFails(
+                "V; creation-date=123",
+                "Invalid character '1' at 0 in \"123\""
+        );
     }
 
     @Test
@@ -429,8 +431,10 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
 
     @Test
     public void testFilenameMissingFails() {
-        this.parseStringFails("V; filename=\"\"",
-                "Failed to convert \"filename\" value \"\"\"\", message: name is empty");
+        this.parseStringFails(
+                "V; filename=\"\"",
+                "filename is empty"
+        );
     }
 
     @Test
@@ -471,8 +475,10 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
 
     @Test
     public void testModificationDateInvalidFails() {
-        this.parseStringFails("V; modification-date=123",
-                "Failed to convert \"modification-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
+        this.parseStringFails(
+                "V; modification-date=123",
+                "Invalid character '1' at 0 in \"123\""
+        );
     }
 
     @Test
@@ -487,8 +493,10 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
 
     @Test
     public void testReadDateInvalidFails() {
-        this.parseStringFails("V; read-date=123",
-                "Failed to convert \"read-date\" value \"123\", message: Invalid character '1' at 0 in \"123\"");
+        this.parseStringFails(
+                "V; read-date=123",
+                "Invalid character '1' at 0 in \"123\""
+        );
     }
 
     @Test
@@ -505,7 +513,7 @@ public final class ContentDispositionHeaderParserTest extends HeaderParserWithPa
     public void testSizeInvalidFails() {
         this.parseStringFails(
                 "V; size=A",
-                "Failed to convert \"size\" value \"A\", message: Invalid number in \"A\""
+                "Invalid number in \"A\""
         );
     }
 

--- a/src/test/java/walkingkooka/net/header/ContentEncodingHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentEncodingHeaderHandlerTest.java
@@ -58,7 +58,7 @@ public final class ContentEncodingHeaderHandlerTest extends NonStringHeaderHandl
 
     @Test
     public void testCheckEmptyListFails() {
-        assertThrows(HeaderException.class, () -> ContentEncodingHeaderHandler.INSTANCE.check(Lists.empty(), HttpHeaderName.CONTENT_ENCODING));
+        assertThrows(HeaderException.class, () -> ContentEncodingHeaderHandler.INSTANCE.check(Lists.empty()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/ContentLanguageHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/ContentLanguageHeaderHandlerTest.java
@@ -32,7 +32,7 @@ public final class ContentLanguageHeaderHandlerTest extends NonStringHeaderHandl
 
     @Test
     public void testCheckEmptyListFails() {
-        assertThrows(HeaderException.class, () -> ContentLanguageHeaderHandler.INSTANCE.check(Lists.empty(), HttpHeaderName.CONTENT_LANGUAGE));
+        assertThrows(HeaderException.class, () -> ContentLanguageHeaderHandler.INSTANCE.check(Lists.empty()));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/EncodedTextHeaderHandlerHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/EncodedTextHeaderHandlerHeaderParserTest.java
@@ -77,7 +77,7 @@ public final class EncodedTextHeaderHandlerHeaderParserTest extends HeaderParser
     }
 
     private EncodedTextHeaderHandlerHeaderParser createHeaderParser() {
-        return EncodedTextHeaderHandlerHeaderParser.with("text", LABEL);
+        return EncodedTextHeaderHandlerHeaderParser.with("text");
     }
 
     @Override
@@ -87,7 +87,7 @@ public final class EncodedTextHeaderHandlerHeaderParserTest extends HeaderParser
 
     @Override
     public EncodedText parseString(final String text) {
-        return EncodedTextHeaderHandlerHeaderParser.parseEncodedText(text, LABEL);
+        return EncodedTextHeaderHandlerHeaderParser.parseEncodedText(text);
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/header/HeaderHandlerTestCase2.java
+++ b/src/test/java/walkingkooka/net/header/HeaderHandlerTestCase2.java
@@ -22,7 +22,6 @@ import walkingkooka.ToStringTesting;
 import walkingkooka.naming.Name;
 import walkingkooka.test.ParseStringTesting;
 import walkingkooka.text.CharSequences;
-import walkingkooka.util.SystemProperty;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -38,7 +37,7 @@ public abstract class HeaderHandlerTestCase2<C extends HeaderHandler<T>, T> exte
 
     @Test
     public void testInvalidHeaderFails() {
-        assertThrows(HeaderException.class, () -> this.handler().parse(this.invalidHeader(), this.name()));
+        assertThrows(HeaderException.class, () -> this.handler().parse(this.invalidHeader()));
     }
 
     abstract String invalidHeader();
@@ -48,26 +47,26 @@ public abstract class HeaderHandlerTestCase2<C extends HeaderHandler<T>, T> exte
         assertThrows(NullPointerException.class, () -> this.check(null));
     }
 
+    // Invalid value type got walkingkooka.net.header.AbsoluteUrlHeaderHandlerTest@29a1505c required AbsoluteUrl
     @Test
     public void testCheckWrongTypeFails() {
-        this.checkTypeFails(this, "Header \"" + this.name() + ": " + this + "\" value type(" + this.getClass().getSimpleName() + ") is not a " + this.valueType());
+        this.checkTypeFails(
+                this,
+                "Invalid value type got " + this + " required " + this.valueType()
+        );
     }
 
-    @Test
-    public void testCheckWrongTypeJavaLangFails() {
-        this.checkTypeFails(new StringBuilder(), "Header \"" + this.name() + ": \" value type(StringBuilder) is not a " + this.valueType());
-    }
-
-    @Test
-    public void testCheckWrongTypeFullyQualifiedTypeNameFails() {
-        this.checkTypeFails(SystemProperty.FILE_SEPARATOR, "Header \"" + this.name() + ": " + SystemProperty.FILE_SEPARATOR + "\" value type(" + SystemProperty.class.getName() + ") is not a " + this.valueType());
-    }
-
-    private void checkTypeFails(final Object value, final String message) {
-        final Exception expected = assertThrows(Exception.class, () -> this.check(value));
-        this.checkEquals(message,
+    private void checkTypeFails(final Object value,
+                                final String message) {
+        final Exception expected = assertThrows(
+                Exception.class,
+                () -> this.check(value)
+        );
+        this.checkEquals(
+                message,
                 expected.getMessage(),
-                "message");
+                "message"
+        );
     }
 
     @Test
@@ -111,8 +110,7 @@ public abstract class HeaderHandlerTestCase2<C extends HeaderHandler<T>, T> exte
     public final T parseString(final String text) {
         return this.handler()
                 .parse(
-                        text,
-                        this.name()
+                        text
                 );
     }
 
@@ -132,7 +130,7 @@ public abstract class HeaderHandlerTestCase2<C extends HeaderHandler<T>, T> exte
     }
 
     final void check(final Object value) {
-        this.handler().check(value, this.name());
+        this.handler().check(value);
     }
 
     final void toTextAndCheck(final T value, final String expected) {

--- a/src/test/java/walkingkooka/net/header/LongHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/LongHeaderHandlerTest.java
@@ -29,7 +29,7 @@ public final class LongHeaderHandlerTest extends
     public void testParseEmptyStringFails() {
         this.parseStringFails(
                 "",
-                new HeaderException("Failed to convert \"Content-Length\" value \"\", message: text is empty")
+                new HeaderException("text is empty")
         );
     }
 
@@ -37,7 +37,7 @@ public final class LongHeaderHandlerTest extends
     public void testParseInvalidNumberFails() {
         this.parseStringFails(
                 "ABC",
-                new HeaderException("Failed to convert \"Content-Length\" value \"ABC\", message: Invalid number in \"ABC\"")
+                new HeaderException("Invalid number in \"ABC\"")
         );
     }
 

--- a/src/test/java/walkingkooka/net/header/OffsetDateTimeHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/OffsetDateTimeHeaderHandlerTest.java
@@ -31,7 +31,7 @@ public final class OffsetDateTimeHeaderHandlerTest extends
     public void testyParseEmptyFails() {
         this.parseStringFails(
                 "",
-                new HeaderException("Failed to convert \"creation-date\" value \"\", message: String index out of range: 0")
+                new HeaderException("text is empty")
         );
     }
 
@@ -39,7 +39,7 @@ public final class OffsetDateTimeHeaderHandlerTest extends
     public void testyParseMissingOpeningDoubleQuoteFails() {
         this.parseStringFails(
                 "abc\"",
-                new HeaderException("Failed to convert \"creation-date\" value \"abc\"\", message: Invalid character 'a' at 0 in \"abc\"\"")
+                new HeaderException("Invalid character 'a' at 0 in \"abc\"\"")
         );
     }
 
@@ -47,7 +47,7 @@ public final class OffsetDateTimeHeaderHandlerTest extends
     public void testyParseMissingClosingDoubleQuoteFails() {
         this.parseStringFails(
                 "\"abc",
-                new HeaderException("Failed to convert \"creation-date\" value \"\"abc\", message: Invalid character 'c' at 3 in \"\"abc\"")
+                new HeaderException("Invalid character 'c' at 3 in \"\"abc\"")
         );
     }
 
@@ -58,8 +58,8 @@ public final class OffsetDateTimeHeaderHandlerTest extends
 
     @Test
     public void testDateWithGmtFails() {
-        assertThrows(HeaderException.class, () -> OffsetDateTimeHeaderHandler.INSTANCE.parse("\"Wed, 21 Oct 2015 07:28:00 GMT\"",
-                ContentDispositionParameterName.CREATION_DATE));
+        assertThrows(HeaderException.class, () -> OffsetDateTimeHeaderHandler.INSTANCE.parse("\"Wed, 21 Oct 2015 07:28:00 GMT\""
+        ));
     }
 
     @Test

--- a/src/test/java/walkingkooka/net/header/QualityFactorHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/QualityFactorHeaderHandlerTest.java
@@ -28,6 +28,22 @@ public final class QualityFactorHeaderHandlerTest extends
     }
 
     @Test
+    public void testParseEmptyStringFails() {
+        this.parseStringFails(
+                "",
+                new HeaderException("text is empty")
+        );
+    }
+
+    @Test
+    public void testParseInvalidNumberFails() {
+        this.parseStringFails(
+                "ABC",
+                new HeaderException("Invalid number in \"ABC\"")
+        );
+    }
+
+    @Test
     public void testParseNegativeFails() {
         this.parseStringFails(
                 "-0.1",

--- a/src/test/java/walkingkooka/net/header/QuotedStringHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/QuotedStringHeaderHandlerTest.java
@@ -25,7 +25,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
     public void testParseControlCharacterFails() {
         this.parseStringFails(
                 "a\\0",
-                new HeaderException("Failed to convert \"Server\" value \"a\\0\", message: Invalid character 'a' at 0 in \"a\\0\"")
+                new HeaderException("Invalid character 'a' at 0 in \"a\\0\"")
         );
     }
 
@@ -33,7 +33,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
     public void testParseNonAsciiFails() {
         this.parseStringFails(
                 "a\u0080",
-                new HeaderException("Failed to convert \"Server\" value \"a\u0080\", message: Invalid character 'a' at 0 in \"a\u0080\"")
+                new HeaderException("Invalid character 'a' at 0 in \"a\u0080\"")
         );
     }
 
@@ -41,7 +41,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
     public void testParseMissingOpeningDoubleQuoteFails() {
         this.parseStringFails(
                 "abc\"",
-                new HeaderException("Failed to convert \"Server\" value \"abc\"\", message: Invalid character 'a' at 0 in \"abc\"\"")
+                new HeaderException("Invalid character 'a' at 0 in \"abc\"\"")
         );
     }
 
@@ -49,7 +49,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
     public void testParseUnsupportedBackslashFails() {
         this.parseStringFails(
                 "a\\bc",
-                new HeaderException("Failed to convert \"Server\" value \"a\\bc\", message: Invalid character 'a' at 0 in \"a\\bc\"")
+                new HeaderException("Invalid character 'a' at 0 in \"a\\bc\"")
         );
     }
 
@@ -63,8 +63,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
         this.parseStringAndCheck(
                 (text) -> this.handlerSupportingBackslashes()
                         .parse(
-                                text,
-                                this.name()
+                                text
                         ),
                 "\"a\\\"bc\"",
                 "a\"bc"
@@ -76,8 +75,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
         this.parseStringAndCheck(
                 (text) -> this.handlerSupportingBackslashes()
                         .parse(
-                                text,
-                                this.name()
+                                text
                         ),
                 "\"a\\\\bc\"",
                 "a\\bc"
@@ -123,8 +121,7 @@ public final class QuotedStringHeaderHandlerTest extends StringHeaderHandlerTest
 
         this.parseStringAndCheck(
                 (t) -> handler.parse(
-                        t,
-                        this.name()
+                        t
                 ),
                 text,
                 value

--- a/src/test/java/walkingkooka/net/header/UnquotedStringHeaderHandlerTest.java
+++ b/src/test/java/walkingkooka/net/header/UnquotedStringHeaderHandlerTest.java
@@ -25,7 +25,7 @@ public final class UnquotedStringHeaderHandlerTest extends QuotedOrUnquotedStrin
     public void testParseOpeningDoubleQuoteFails() {
         this.parseStringFails(
                 "\"abc",
-                new HeaderException("Failed to convert \"Server\" value \"\"abc\", message: Invalid character '\\\"' at 0 in \"\"abc\"")
+                new HeaderException("Invalid character '\\\"' at 0 in \"\"abc\"")
         );
     }
 
@@ -33,7 +33,7 @@ public final class UnquotedStringHeaderHandlerTest extends QuotedOrUnquotedStrin
     public void testParseBackslashFails() {
         this.parseStringFails(
                 "a\\bc",
-                new HeaderException("Failed to convert \"Server\" value \"a\\bc\", message: Invalid character '\\\\' at 1 in \"a\\bc\"")
+                new HeaderException("Invalid character '\\\\' at 1 in \"a\\bc\"")
         );
     }
 

--- a/src/test/java/walkingkooka/net/http/HttpEntityTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpEntityTest.java
@@ -72,6 +72,207 @@ public final class HttpEntityTest implements ParseStringTesting<HttpEntity>,
     }
 
     @Test
+    public void testParseHeaderAcceptFails() {
+        this.parseStringFails(
+                "Accept: ???\r\n",
+                new IllegalArgumentException("Accept: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderAcceptCharsetFails() {
+        this.parseStringFails(
+                "Accept-Charset: ???\r\n",
+                new IllegalArgumentException("Accept-Charset: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderAcceptEncodingFails() {
+        this.parseStringFails(
+                "Accept-Encoding: ???\r\n",
+                new IllegalArgumentException("Accept-Encoding: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderAcceptLanguageFails() {
+        this.parseStringFails(
+                "Accept-Language: ???\r\n",
+                new IllegalArgumentException("Accept-Language: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderAgeFails() {
+        this.parseStringFails(
+                "Age: ???\r\n",
+                new IllegalArgumentException("Age: Invalid number in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderCacheControlFails() {
+        this.parseStringFails(
+                "Cache-Control: ???\r\n",
+                new IllegalArgumentException("Cache-Control: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderContentDispositionFails() {
+        this.parseStringFails(
+                "Content-Disposition: ???\r\n",
+                new IllegalArgumentException("Content-Disposition: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderContentEncodingFails() {
+        this.parseStringFails(
+                "Content-ENcoding: ???\r\n",
+                new IllegalArgumentException("Content-Encoding: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderContentLanguageFails() {
+        this.parseStringFails(
+                "Content-Language: ???\r\n",
+                new IllegalArgumentException("Content-Language: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+
+    @Test
+    public void testParseHeaderContentLengthFails() {
+        this.parseStringFails(
+                "Content-Length: ???\r\n",
+                new IllegalArgumentException("Content-Length: Invalid number in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderContentRangeFails() {
+        this.parseStringFails(
+                "Content-Range: ???\r\n",
+                new IllegalArgumentException("Content-Range: Unit missing from \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderContentTypeFails() {
+        this.parseStringFails(
+                "Content-Type: type/?\r\n",
+                new IllegalArgumentException("Content-Type: Invalid character '?' at 6 in \" type/?\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderCookieFails() {
+        this.parseStringFails(
+                "Cookie: ???\r\n",
+                new IllegalArgumentException("Cookie: Invalid character '?' at 0 in \"???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderDateFails() {
+        this.parseStringFails(
+                "Date: ???\r\n",
+                new IllegalArgumentException("Date: Invalid date in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderEtagFails() {
+        this.parseStringFails(
+                "Etag: ???\r\n",
+                new IllegalArgumentException("ETag: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderFromFails() {
+        this.parseStringFails(
+                "From: ???\r\n",
+                new IllegalArgumentException("From: Invalid email \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderIfMatchFails() {
+        this.parseStringFails(
+                "If-Match: ???\r\n",
+                new IllegalArgumentException("If-Match: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderIfModifiedSinceFails() {
+        this.parseStringFails(
+                "If-Modified-Since: ???\r\n",
+                new IllegalArgumentException("If-Modified-Since: Invalid date in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderIfNoneMatchFails() {
+        this.parseStringFails(
+                "If-None-Match: ???\r\n",
+                new IllegalArgumentException("If-None-Match: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderIfRangeFails() {
+        this.parseStringFails(
+                "If-Range: ???\r\n",
+                new IllegalArgumentException("If-Range: Invalid date in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderIfUnmodifiedSinceFails() {
+        this.parseStringFails(
+                "If-Unmodified-Since: ???\r\n",
+                new IllegalArgumentException("If-Unmodified-Since: Invalid date in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderLinkFails() {
+        this.parseStringFails(
+                "Link: ???\r\n",
+                new IllegalArgumentException("Link: Invalid character '?' at 1 in \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderRangeFails() {
+        this.parseStringFails(
+                "Range: ???\r\n",
+                new IllegalArgumentException("Range: Missing unit and '=' from header value \" ???\"")
+        );
+    }
+
+    @Test
+    public void testParseHeaderRefererFails() {
+        this.parseStringFails(
+                "Referer: ???\r\n",
+                new IllegalArgumentException("Referer: no protocol:  ???")
+        );
+    }
+
+    @Test
+    public void testParseHeaderSetCookieFails() {
+        this.parseStringFails(
+                "Set-Cookie: ???\r\n",
+                new IllegalArgumentException("Set-Cookie: Invalid character '?' at 0 in \"???\"")
+        );
+    }
+
+    @Test
     public void testParseEmptyHeadersEmptyBody() {
         this.parseStringAndCheck(
                 "\r\n",
@@ -181,22 +382,6 @@ public final class HttpEntityTest implements ParseStringTesting<HttpEntity>,
                         HttpHeaderName.ACCEPT,
                         Accept.parse("*/*")
                 ).setBodyText("Body123")
-        );
-    }
-
-    @Test
-    public void testParseHeaderMissingValueFails() {
-        this.parseStringFails(
-                "Content-Type\r\n",
-                new IllegalArgumentException("Failed to convert \"Content-Type\" value \"\", message: text contains only whitespace=\"\"")
-        );
-    }
-
-    @Test
-    public void testParseHeaderInvalidValueFails() {
-        this.parseStringFails(
-                "Content-Type: BAD\r\n",
-                new IllegalArgumentException("Missing type at 4 in \" BAD\"")
         );
     }
 

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestParserTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestParserTest.java
@@ -70,7 +70,7 @@ public final class HttpRequestParserTest implements ClassTesting2<HttpRequestPar
     public void testInvalidHeaderFails3() {
         this.parseStringFails(
                 "GET / HTTP/1.0\r\nContent-Length:A",
-                new HeaderException("Failed to convert \"Content-Length\" value \"A\", message: Invalid number in \"A\"")
+                new HeaderException("Content-Length: Invalid number in \"A\"")
         );
     }
 

--- a/src/test/java/walkingkooka/net/http/server/HttpResponseParserTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpResponseParserTest.java
@@ -57,7 +57,7 @@ public final class HttpResponseParserTest implements ClassTesting2<HttpResponseP
     public void testInvalidHeaderFails() {
         this.parseStringFails(
                 "HTTP/1.0 200 OK\r\nContent-Length:A",
-                new HeaderException("Failed to convert \"Content-Length\" value \"A\", message: Invalid number in \"A\"")
+                new HeaderException("Content-Length: Invalid number in \"A\"")
         );
     }
 

--- a/src/test/java/walkingkooka/net/http/server/LineReaderTest.java
+++ b/src/test/java/walkingkooka/net/http/server/LineReaderTest.java
@@ -108,7 +108,7 @@ public final class LineReaderTest implements ClassTesting2<LineReader>, ToString
                 () -> LineReader.with("Content-Length:A").readHeaders()
         );
         this.checkEquals(
-                "Failed to convert \"Content-Length\" value \"A\", message: Invalid number in \"A\"",
+                "Content-Length: Invalid number in \"A\"",
                 thrown.getMessage()
         );
     }


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/545
- ContentType fail message should mention header name