### PR TITLE
HttpEntity.toString content-type=text not hex dumped

### DIFF
--- a/src/main/java/walkingkooka/net/http/HttpEntity.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntity.java
@@ -21,7 +21,6 @@ import javaemul.internal.annotations.GwtIncompatible;
 import walkingkooka.Binary;
 import walkingkooka.CanBeEmpty;
 import walkingkooka.Cast;
-import walkingkooka.UsesToStringBuilder;
 import walkingkooka.collect.Range;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
@@ -52,8 +51,7 @@ import java.util.stream.Collectors;
 public abstract class HttpEntity implements HasHeaders,
         CanBeEmpty,
         HasText,
-        TreePrintable,
-        UsesToStringBuilder {
+        TreePrintable {
 
     /**
      * {@link Binary} with no body or bytes.
@@ -702,30 +700,16 @@ public abstract class HttpEntity implements HasHeaders,
         {
             {
                 // headers
-                final Map<HttpHeaderName<?>, HttpEntityHeaderList> headers = Maps.sorted();
-                headers.putAll(
-                        this.headers2()
-                );
-                ;
+                final Map<HttpHeaderName<?>, HttpEntityHeaderList> headers = this.alphaSortedHeaders();
+
                 if (false == headers.isEmpty()) {
                     printer.println("header(s)");
                     printer.indent();
                     {
-                        for (final Entry<HttpHeaderName<?>, HttpEntityHeaderList> headerAndValues : headers.entrySet()) {
-                            final HttpHeaderName<?> name = headerAndValues.getKey();
-
-                            for (final Object value : headerAndValues.getValue()) {
-                                printer.println(
-                                        "" +
-                                                name +
-                                                HttpEntity.HEADER_NAME_SEPARATOR +
-                                                " " +
-                                                name.headerText(
-                                                        Cast.to(value)
-                                                )
-                                );
-                            }
-                        }
+                        this.printHeaders(
+                                headers,
+                                printer
+                        );
                     }
                     printer.outdent();
                 }
@@ -733,6 +717,33 @@ public abstract class HttpEntity implements HasHeaders,
             this.printTreeBody(printer);
         }
         printer.outdent();
+    }
+
+    final Map<HttpHeaderName<?>, HttpEntityHeaderList> alphaSortedHeaders() {
+        final Map<HttpHeaderName<?>, HttpEntityHeaderList> headers = Maps.sorted();
+        headers.putAll(
+                this.headers2()
+        );
+        return headers;
+    }
+
+    final void printHeaders(final Map<HttpHeaderName<?>, HttpEntityHeaderList> headers,
+                            final IndentingPrinter printer) {
+        for (final Entry<HttpHeaderName<?>, HttpEntityHeaderList> headerAndValues : headers.entrySet()) {
+            final HttpHeaderName<?> name = headerAndValues.getKey();
+
+            for (final Object value : headerAndValues.getValue()) {
+                printer.println(
+                        "" +
+                                name +
+                                HttpEntity.HEADER_NAME_SEPARATOR +
+                                " " +
+                                name.headerText(
+                                        Cast.to(value)
+                                )
+                );
+            }
+        }
     }
 
     abstract void printTreeBody(final IndentingPrinter printer);

--- a/src/main/java/walkingkooka/net/http/HttpEntityBinary.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntityBinary.java
@@ -18,20 +18,10 @@
 package walkingkooka.net.http;
 
 import walkingkooka.Binary;
-import walkingkooka.ToStringBuilder;
-import walkingkooka.ToStringBuilderOption;
 import walkingkooka.collect.map.Maps;
-import walkingkooka.net.header.CharsetName;
 import walkingkooka.net.header.HttpHeaderName;
-import walkingkooka.net.header.MediaType;
-import walkingkooka.net.header.MediaTypeParameterName;
-import walkingkooka.text.Ascii;
-import walkingkooka.text.CharSequences;
-import walkingkooka.text.LineEnding;
 
-import java.nio.charset.Charset;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * A http entity containing headers and body. Note that the content-length is not automatically updated in any factory or
@@ -101,68 +91,4 @@ final class HttpEntityBinary extends HttpEntityNotEmpty {
                 EMPTY :
                 new HttpEntityBinary(Maps.readOnly(headers), body);
     }
-
-    // Object....................................................................................................
-
-    /**
-     * The {@link String} produced looks almost like a http entity, each header will appear on a single, a colon separates
-     * the header name and value, and a blank line between headers and body, with the body bytes appearing in hex form.
-     */
-    @Override
-    void toStringBody(final ToStringBuilder b) {
-        final Binary body = this.body;
-        byte[] bodyBytes = body.value();
-
-        final Optional<MediaType> mediaType = HttpHeaderName.CONTENT_TYPE.header(this);
-        if (mediaType.isPresent()) {
-            final Optional<CharsetName> charsetName = MediaTypeParameterName.CHARSET.parameterValue(mediaType.get());
-            if (charsetName.isPresent()) {
-                final Optional<Charset> charset = charsetName.get().charset();
-                if (charset.isPresent()) {
-                    b.value(new String(bodyBytes, charset.get()));
-                    bodyBytes = null;
-                }
-            }
-        }
-
-        if (null != bodyBytes && false == body.isEmpty()) {
-            // hex dump
-            // offset-HEX_DUMP_WIDTH-chars space hexdigit *HEX_DUMP_WIDTH space separated ascii
-            b.enable(ToStringBuilderOption.HEX_BYTES);
-            b.valueSeparator(" ");
-            b.labelSeparator(" ");
-
-            final int length = bodyBytes.length;
-            for (int i = 0; i < length; i = i + HEX_DUMP_WIDTH) {
-                // offset
-                b.append(CharSequences.padLeft(Integer.toHexString(i), 8, '0').toString());
-                b.append(' ');
-
-                for (int j = 0; j < HEX_DUMP_WIDTH; j++) {
-                    final int k = i + j;
-                    if (k < length) {
-                        b.value(bodyBytes[k]);
-                    } else {
-                        b.value("  ");
-                    }
-                }
-
-                b.append(' ');
-
-                for (int j = 0; j < HEX_DUMP_WIDTH; j++) {
-                    final int k = i + j;
-                    if (k < length) {
-                        final char c = (char) bodyBytes[k];
-                        b.append(Ascii.isPrintable(c) ? c : UNPRINTABLE_CHAR);
-                    } else {
-                        b.append(' ');
-                    }
-                }
-
-                b.append(LineEnding.SYSTEM);
-            }
-        }
-    }
-
-    private final static int HEX_DUMP_WIDTH = 16;
 }

--- a/src/main/java/walkingkooka/net/http/HttpEntityEmpty.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntityEmpty.java
@@ -18,7 +18,6 @@
 package walkingkooka.net.http;
 
 import walkingkooka.Binary;
-import walkingkooka.ToStringBuilder;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HttpHeaderName;
 import walkingkooka.net.header.MediaType;
@@ -131,11 +130,6 @@ final class HttpEntityEmpty extends HttpEntity {
     @Override
     public String toString() {
         return "";
-    }
-
-    @Override
-    public void buildToString(final ToStringBuilder toStringBuilder) {
-        // nop
     }
 
     // TreePrintable....................................................................................................

--- a/src/main/java/walkingkooka/net/http/HttpEntityText.java
+++ b/src/main/java/walkingkooka/net/http/HttpEntityText.java
@@ -18,7 +18,6 @@
 package walkingkooka.net.http;
 
 import walkingkooka.Binary;
-import walkingkooka.ToStringBuilder;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.header.HttpHeaderName;
 
@@ -81,10 +80,5 @@ final class HttpEntityText extends HttpEntityNotEmpty {
         return headers.isEmpty() && this.bodyText().isEmpty() ?
                 EMPTY :
                 HttpEntityBinary.with(headers, body);
-    }
-
-    @Override
-    void toStringBody(final ToStringBuilder b) {
-        b.append(this.bodyText());
     }
 }

--- a/src/test/java/walkingkooka/net/http/HttpEntityBinaryTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpEntityBinaryTest.java
@@ -139,7 +139,8 @@ public final class HttpEntityBinaryTest extends HttpEntityNotEmptyTestCase<HttpE
                         HttpHeaderName.CONTENT_LENGTH, 257L,
                         HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8),
                         HttpHeaderName.SERVER, "Server 123", "AB\nC"),
-                "Content-Length: 257\r\nContent-Type: text/plain; charset=UTF-8\r\nServer: Server 123\r\n\r\nAB\nC");
+                "Content-Length: 257\r\nContent-Type: text/plain; charset=UTF-8\r\nServer: Server 123\r\n\r\nAB\\n\r\nC"
+        );
     }
 
     @Test
@@ -160,48 +161,76 @@ public final class HttpEntityBinaryTest extends HttpEntityNotEmptyTestCase<HttpE
     @Test
     public void testToStringBinary() {
         final String letters = "a";
-        this.toStringAndCheck(this.createHttpEntity(HttpHeaderName.CONTENT_LENGTH, 257L, letters),
+        this.toStringAndCheck(
+                this.createHttpEntity(
+                        HttpHeaderName.CONTENT_LENGTH,
+                        257L, letters
+                ),
                 "Content-Length: 257\r\n\r\n" +
-                        "00000000 61                                              a               " + LineEnding.SYSTEM);
+                        "00000000 61                                              a               " + LineEnding.CRNL
+        );
     }
 
     @Test
     public void testToStringBinaryUnprintable() {
         final String letters = "\0";
-        this.toStringAndCheck(this.createHttpEntity(HttpHeaderName.CONTENT_LENGTH, 257L, letters),
+        this.toStringAndCheck(
+                this.createHttpEntity(
+                        HttpHeaderName.CONTENT_LENGTH,
+                        257L,
+                        letters
+                ),
                 "Content-Length: 257\r\n\r\n" +
-                        "00000000 00                                              .               " + LineEnding.SYSTEM);
+                        "00000000 00                                              .               " + LineEnding.CRNL
+        );
     }
 
     @Test
     public void testToStringBinaryMultiLine() {
         final String letters = "abcdefghijklmnopq";
-        this.toStringAndCheck(this.createHttpEntity(HttpHeaderName.CONTENT_LENGTH, 257L, letters),
+        this.toStringAndCheck(
+                this.createHttpEntity(
+                        HttpHeaderName.CONTENT_LENGTH,
+                        257L,
+                        letters
+                ),
                 "Content-Length: 257\r\n\r\n" +
-                        "00000000 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 abcdefghijklmnop" + LineEnding.SYSTEM +
-                        "00000010 71                                              q               " + LineEnding.SYSTEM);
+                        "00000000 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 abcdefghijklmnop" + LineEnding.CRNL +
+                        "00000010 71                                              q               " + LineEnding.CRNL
+        );
     }
 
     @Test
     public void testToStringBinaryMultiLine2() {
         final String letters = "\n\0cdefghijklmnopq";
-        this.toStringAndCheck(this.createHttpEntity(HttpHeaderName.CONTENT_LENGTH, 257L, letters),
+        this.toStringAndCheck(
+                this.createHttpEntity(
+                        HttpHeaderName.CONTENT_LENGTH,
+                        257L,
+                        letters
+                ),
                 "Content-Length: 257\r\n\r\n" +
-                        "00000000 0a 00 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 ..cdefghijklmnop" + LineEnding.SYSTEM +
-                        "00000010 71                                              q               " + LineEnding.SYSTEM);
+                        "00000000 0a 00 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 ..cdefghijklmnop" + LineEnding.CRNL +
+                        "00000010 71                                              q               " + LineEnding.CRNL
+        );
     }
 
     @Test
     public void testToStringMultipleHeadersBinary() {
         final String letters = "\n\0cdefghijklmnopq";
-        this.toStringAndCheck(this.createHttpEntity(HttpHeaderName.CONTENT_LENGTH, 257L,
+        this.toStringAndCheck(
+                this.createHttpEntity(
+                        HttpHeaderName.CONTENT_LENGTH, 257L,
                         HttpHeaderName.CONTENT_TYPE, MediaType.BINARY,
-                        HttpHeaderName.SERVER, "Server 123", letters),
+                        HttpHeaderName.SERVER, "Server 123",
+                        letters
+                ),
                 "Content-Length: 257\r\n" +
                         "Content-Type: application/octet-stream\r\n" +
                         "Server: Server 123\r\n\r\n" +
-                        "00000000 0a 00 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 ..cdefghijklmnop" + LineEnding.SYSTEM +
-                        "00000010 71                                              q               " + LineEnding.SYSTEM);
+                        "00000000 0a 00 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70 ..cdefghijklmnop" + LineEnding.CRNL +
+                        "00000010 71                                              q               " + LineEnding.CRNL
+        );
     }
 
     // helper...........................................................................................................

--- a/src/test/java/walkingkooka/net/http/HttpEntityTextTest.java
+++ b/src/test/java/walkingkooka/net/http/HttpEntityTextTest.java
@@ -146,10 +146,32 @@ public final class HttpEntityTextTest extends HttpEntityNotEmptyTestCase<HttpEnt
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(HttpEntityText.with(Maps.of(HttpHeaderName.CONTENT_LENGTH, HttpEntityHeaderList.one(HttpHeaderName.CONTENT_LENGTH, 257L),
-                        HttpHeaderName.CONTENT_TYPE, HttpEntityHeaderList.one(HttpHeaderName.CONTENT_TYPE, MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8)),
-                        HttpHeaderName.SERVER, HttpEntityHeaderList.one(HttpHeaderName.SERVER, "Server 123")), "AB\nC"),
-                "Content-Length: 257\r\nContent-Type: text/plain; charset=UTF-8\r\nServer: Server 123\r\n\r\nAB\nC");
+        this.toStringAndCheck(
+                HttpEntityText.with(
+                        Maps.of(
+                                HttpHeaderName.CONTENT_LENGTH,
+                                HttpEntityHeaderList.one(
+                                        HttpHeaderName.CONTENT_LENGTH,
+                                        257L
+                                ),
+                                HttpHeaderName.CONTENT_TYPE,
+                                HttpEntityHeaderList.one(
+                                        HttpHeaderName.CONTENT_TYPE,
+                                        MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8)
+                                ),
+                                HttpHeaderName.SERVER,
+                                HttpEntityHeaderList.one(
+                                        HttpHeaderName.SERVER,
+                                        "Server 123"
+                                )
+                        ), "AB\nC"),
+                "Content-Length: 257\r\n" +
+                        "Content-Type: text/plain; charset=UTF-8\r\n" +
+                        "Server: Server 123\r\n" +
+                        "\r\n" +
+                        "AB\\n\r\n" +
+                        "C"
+        );
     }
 
     // TreePrintable....................................................................................................

--- a/src/test/java/walkingkooka/net/http/server/HttpRequestValueTest.java
+++ b/src/test/java/walkingkooka/net/http/server/HttpRequestValueTest.java
@@ -193,7 +193,7 @@ public final class HttpRequestValueTest implements ClassTesting2<HttpRequestValu
         this.toStringAndCheck(this.createObject(),
                 "CONNECT /path1/path2?query3=value4 HTTP/1.1\r\n" +
                         "Content-Type: text/html; charset=UTF-8\r\n" +
-                        "Cookie: cookie1: value1;\r\n" +
+                        "Cookie: cookie1=value1;\r\n" +
                         "\r\n" +
                         "body-text-123");
     }

--- a/src/test/java/walkingkooka/net/http/server/RecordingHttpResponseTest.java
+++ b/src/test/java/walkingkooka/net/http/server/RecordingHttpResponseTest.java
@@ -169,7 +169,7 @@ public final class RecordingHttpResponseTest extends HttpResponseTestCase2<Recor
                 "503 Problem x y z\r\n" +
                         "Server: Server 123\r\n" +
                         "\r\n" +
-                        "00000000 41 42 43                                        ABC             \n");
+                        "00000000 41 42 43                                        ABC             \r\n");
     }
 
     @Test
@@ -183,7 +183,7 @@ public final class RecordingHttpResponseTest extends HttpResponseTestCase2<Recor
                 "HTTP/1.1 503 Problem x y z\r\n" +
                         "Server: Server 123\r\n" +
                         "\r\n" +
-                        "00000000 41 42 43                                        ABC             \n");
+                        "00000000 41 42 43                                        ABC             \r\n");
     }
 
     @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/548
- HttpEntity.toString should not do binary dump for text content-types