### PR TITLE
MediaType parse suffix fix

### DIFF
--- a/src/test/java/walkingkooka/net/header/MediaTypeHeaderParserTestCase.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeHeaderParserTestCase.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.map.Maps;
 
 import java.util.Map;
+import java.util.Optional;
 
 public abstract class MediaTypeHeaderParserTestCase<P extends MediaTypeHeaderParser, V> extends HeaderParserWithParametersTestCase<P,
         V> {
@@ -277,54 +278,94 @@ public abstract class MediaTypeHeaderParserTestCase<P extends MediaTypeHeaderPar
 
     @Test
     public final void testTypeSlashSubTypeTabSpace() {
-        this.parseStringAndCheck("abc/def\t ",
+        this.parseStringAndCheck(
+                "abc/def\t ",
                 "abc",
-                "def");
+                "def"
+        );
     }
 
     @Test
     public final void testTypeSlashSubTypePlusSuffix() {
-        this.parseStringAndCheck("abc/def+suffix",
+        this.parseStringAndCheck(
+                "abc/def+suffix123",
                 "abc",
-                "def+suffix");
+                "def",
+                Optional.of("suffix123"),
+                MediaType.NO_PARAMETERS
+        );
     }
 
     @Test
     public final void testTypeSlashSubTypePrefixSuffix() {
-        this.parseStringAndCheck("a/b+suffix",
+        this.parseStringAndCheck(
+                "a/b+suffix123",
                 "a",
-                "b+suffix");
+                "b",
+                Optional.of("suffix123"),
+                MediaType.NO_PARAMETERS
+        );
     }
 
     @Test
     public final void testTypeSlashVendorDotSubType() {
-        this.parseStringAndCheck("a/vnd.b",
+        this.parseStringAndCheck(
+                "a/vnd.b",
                 "a",
-                "vnd.b");
+                "vnd.b"
+        );
     }
 
     @Test
     public final void testTypeSlashSubTypeParameter() {
-        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";p=v",
+        this.parseStringAndCheck(
+                TYPE + "/" + SUBTYPE + ";p=v",
                 TYPE,
                 SUBTYPE,
-                parameters("p", "v"));
+                parameters("p", "v")
+        );
     }
 
     @Test
     public final void testTypeSlashSubTypeParameter2() {
-        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=value",
+        this.parseStringAndCheck(
+                TYPE + "/" + SUBTYPE + ";parameter=value",
                 TYPE,
                 SUBTYPE,
-                parameters("parameter", "value"));
+                parameters("parameter", "value")
+        );
     }
 
     @Test
     public final void testTypeSlashSubTypeParameterQuotedValue() {
-        this.parseStringAndCheck(TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
+        this.parseStringAndCheck(
+                TYPE + "/" + SUBTYPE + ";parameter=\"value\"",
                 TYPE,
                 SUBTYPE,
-                parameters("parameter", "value"));
+                parameters("parameter", "value")
+        );
+    }
+
+    @Test
+    public final void testTypeSlashSubTypePlusSuffixParameter() {
+        this.parseStringAndCheck(
+                TYPE + "/" + SUBTYPE + "+suffix123;parameter=\"quoted-value-123\"",
+                TYPE,
+                SUBTYPE,
+                Optional.of("suffix123"),
+                parameters("parameter", "quoted-value-123")
+        );
+    }
+
+    @Test
+    public final void testTypeSlashSubTypePlusSuffixParameterParameter() {
+        this.parseStringAndCheck(
+                TYPE + "/" + SUBTYPE + "+suffix123;parameter1=value1;parameter2=value2",
+                TYPE,
+                SUBTYPE,
+                Optional.of("suffix123"),
+                parameters("parameter1", "value1", "parameter2", "value2")
+        );
     }
 
     @Test
@@ -514,25 +555,66 @@ public abstract class MediaTypeHeaderParserTestCase<P extends MediaTypeHeaderPar
                 MediaTypeParameterName.with(name2), value2);
     }
 
-    private void parseStringAndCheck(final String text, final String type, final String subtype) {
-        this.check(MediaType.parse(text), type, subtype);
+    private void parseStringAndCheck(final String text,
+                                     final String type,
+                                     final String subtype) {
+        this.check(
+                MediaType.parse(text),
+                type,
+                subtype
+        );
+    }
+
+    private void parseStringAndCheck(final String text,
+                                     final String type,
+                                     final String subtype,
+                                     final Map<MediaTypeParameterName<?>, Object> parameters) {
+        this.parseStringAndCheck(
+                text,
+                type,
+                subtype,
+                MediaType.NO_SUFFIX,
+                parameters
+        );
     }
 
     abstract void parseStringAndCheck(final String text,
                                       final String type,
                                       final String subtype,
+                                      final Optional<String> suffix,
                                       final Map<MediaTypeParameterName<?>, Object> parameters);
 
     final void check(final MediaType mediaType, final String type, final String subtype) {
-        check(mediaType, type, subtype, MediaType.NO_PARAMETERS);
+        check(
+                mediaType,
+                type,
+                subtype,
+                MediaType.NO_SUFFIX,
+                MediaType.NO_PARAMETERS
+        );
     }
 
     final void check(final MediaType mediaType,
                      final String type,
                      final String subtype,
                      final Map<MediaTypeParameterName<?>, Object> parameters) {
+        this.check(
+                mediaType,
+                type,
+                subtype,
+                MediaType.NO_SUFFIX,
+                parameters
+        );
+    }
+
+    final void check(final MediaType mediaType,
+                     final String type,
+                     final String subtype,
+                     final Optional<String> suffix,
+                     final Map<MediaTypeParameterName<?>, Object> parameters) {
         this.checkEquals(type, mediaType.type(), "type=" + mediaType);
         this.checkEquals(subtype, mediaType.subType(), "subType=" + mediaType);
+        this.checkEquals(suffix, mediaType.suffix(), "suffix=" + mediaType);
         this.checkEquals(parameters, mediaType.parameters(), "parameters=" + mediaType);
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeListHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeListHeaderParserTest.java
@@ -23,6 +23,7 @@ import walkingkooka.text.CharSequences;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public final class MediaTypeListHeaderParserTest extends MediaTypeHeaderParserTestCase<MediaTypeListHeaderParser,
         List<MediaType>> {
@@ -96,38 +97,51 @@ public final class MediaTypeListHeaderParserTest extends MediaTypeHeaderParserTe
                 MediaType.with("type1", "subtype1").setParameters(this.parameters("q", 0.25f)));
     }
 
-    @Override void parseStringAndCheck(final String text,
-                                       final String type,
-                                       final String subtype,
-                                       final Map<MediaTypeParameterName<?>, Object> parameters) {
-        parseStringAndCheckOne(text, type, subtype, parameters);
-        parseStringAndCheckRepeated(text, type, subtype, parameters);
-        parseStringAndCheckSeveral(text, type, subtype, parameters);
+    @Override
+    void parseStringAndCheck(final String text,
+                             final String type,
+                             final String subtype,
+                             final Optional<String> suffix,
+                             final Map<MediaTypeParameterName<?>, Object> parameters) {
+        parseStringAndCheckOne(text, type, subtype, suffix, parameters);
+        parseStringAndCheckRepeated(text, type, subtype, suffix, parameters);
+        parseStringAndCheckSeveral(text, type, subtype, suffix, parameters);
     }
 
     private void parseStringAndCheckOne(final String text,
                                         final String type,
                                         final String subtype,
+                                        final Optional<String> suffix,
                                         final Map<MediaTypeParameterName<?>, Object> parameters) {
         final List<MediaType> result = MediaTypeListHeaderParser.parseMediaTypeList(text);
         this.checkEquals(1, result.size(), "parse " + CharSequences.quote(text) + " got " + result);
-        this.check(result.get(0), type, subtype, parameters);
+
+        this.check(
+                result.get(0),
+                type,
+                subtype,
+                suffix,
+                parameters
+        );
     }
 
     private void parseStringAndCheckRepeated(final String text,
                                              final String type,
                                              final String subtype,
+                                             final Optional<String> suffix,
                                              final Map<MediaTypeParameterName<?>, Object> parameters) {
         final String parsed = text + MediaType.SEPARATOR + text;
         final List<MediaType> result = MediaTypeListHeaderParser.parseMediaTypeList(parsed);
         this.checkEquals(2, result.size(), "parse " + CharSequences.quote(parsed) + " got " + result);
-        this.check(result.get(0), type, subtype, parameters);
-        this.check(result.get(1), type, subtype, parameters);
+
+        this.check(result.get(0), type, subtype, suffix, parameters);
+        this.check(result.get(1), type, subtype, suffix, parameters);
     }
 
     private void parseStringAndCheckSeveral(final String text,
                                             final String type,
                                             final String subtype,
+                                            final Optional<String> suffix,
                                             final Map<MediaTypeParameterName<?>, Object> parameters) {
         final String parsed = "TYPE1/SUBTYPE1," + text + ",TYPE2/SUBTYPE2;x=y," + text;
         final List<MediaType> result = MediaTypeListHeaderParser.parseMediaTypeList(parsed);
@@ -135,10 +149,10 @@ public final class MediaTypeListHeaderParserTest extends MediaTypeHeaderParserTe
         this.checkEquals(4, result.size(), "parse " + CharSequences.quote(parsed) + " got " + result);
 
         this.check(result.get(0), "TYPE1", "SUBTYPE1");
-        this.check(result.get(1), type, subtype, parameters);
+        this.check(result.get(1), type, subtype, suffix, parameters);
 
-        this.check(result.get(2), "TYPE2", "SUBTYPE2", parameters("x", "y"));
-        this.check(result.get(3), type, subtype, parameters);
+        this.check(result.get(2), "TYPE2", "SUBTYPE2", MediaType.NO_SUFFIX, parameters("x", "y"));
+        this.check(result.get(3), type, subtype, suffix, parameters);
     }
 
     private void parseStringAndCheck2(final String text, final MediaType... mediaTypes) {

--- a/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderParserTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeOneHeaderParserTest.java
@@ -20,6 +20,7 @@ package walkingkooka.net.header;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
 public final class MediaTypeOneHeaderParserTest extends MediaTypeHeaderParserTestCase<MediaTypeOneHeaderParser,
         MediaType> {
@@ -38,11 +39,19 @@ public final class MediaTypeOneHeaderParserTest extends MediaTypeHeaderParserTes
         this.parseStringInvalidCharacterFails("type/subtype;p=v,");
     }
 
-    @Override void parseStringAndCheck(final String text,
-                                       final String type,
-                                       final String subtype,
-                                       final Map<MediaTypeParameterName<?>, Object> parameters) {
-        this.check(MediaTypeOneHeaderParser.parseMediaType(text), type, subtype, parameters);
+    @Override //
+    void parseStringAndCheck(final String text,
+                             final String type,
+                             final String subtype,
+                             final Optional<String> suffix,
+                             final Map<MediaTypeParameterName<?>, Object> parameters) {
+        this.check(
+                MediaTypeOneHeaderParser.parseMediaType(text),
+                type,
+                subtype,
+                suffix,
+                parameters
+        );
     }
 
     @Override


### PR DESCRIPTION
- Previously parsing consumed the suffix within the sub-type.

- Closes https://github.com/mP1/walkingkooka-net/issues/585
- MediaType.parse fails to spot suffixes