### PR TITLE
MediaType type/subType/suffix parser CharPredicate validation

### DIFF
--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -340,7 +340,11 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
     private final String type;
 
     private static String checkType(final String type) {
-        return check(type, "type");
+        return check(
+                type,
+                "type",
+                MediaTypeHeaderParser.TYPE
+        );
     }
 
     // sub type ...................................................................................................
@@ -371,14 +375,24 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
     private final String subType;
 
     private static String checkSubType(final String subType) {
-        return check(subType, "subType");
+        return check(
+                subType,
+                "subType",
+                MediaTypeHeaderParser.SUB_TYPE
+        );
     }
 
     /**
      * Checks that the value contains valid token characters.
      */
-    private static String check(final String value, final String label) {
-        CharPredicates.failIfNullOrEmptyOrFalse(value, label, RFC2045TOKEN);
+    private static String check(final String value,
+                                final String label,
+                                final CharPredicate predicate) {
+        CharPredicates.failIfNullOrEmptyOrFalse(
+                value,
+                label,
+                predicate
+        );
         return value;
     }
 
@@ -395,7 +409,7 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
      * Would be setter that returns a {@link MediaType} with the given suffix creating a new instance if necessary.
      */
     public MediaType setSuffix(final Optional<String> suffix) {
-        Objects.requireNonNull(suffix, "suffix");
+        checkSuffix(suffix);
 
         final MediaType mediaType;
         if (this.suffix.equals(suffix)) {
@@ -426,6 +440,20 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
     //   name, and "+bar" is the structured suffix.  A media type such as
     //   "application/foo+bar+baz" is not allowed.
     private final Optional<String> suffix;
+
+    private static Optional<String> checkSuffix(final Optional<String> suffix) {
+        Objects.requireNonNull(suffix, "suffix");
+
+        if (suffix.isPresent()) {
+            CharPredicates.failIfNullOrEmptyOrFalse(
+                    suffix.get(),
+                    "suffix",
+                    MediaTypeHeaderParser.SUFFIX
+            );
+        }
+
+        return suffix;
+    }
 
     // HasCaseSensitivity ...............................................................................................
 

--- a/src/main/java/walkingkooka/net/header/MediaTypeHeaderParser.java
+++ b/src/main/java/walkingkooka/net/header/MediaTypeHeaderParser.java
@@ -104,19 +104,21 @@ abstract class MediaTypeHeaderParser extends HeaderParserWithParameters<MediaTyp
      * Handles parsing the type part of a media type.
      */
     private String type() {
-        final String type = this.token(RFC2045TOKEN);
+        final String type = this.token(TYPE);
         if (!this.hasMoreCharacters()) {
-            failEmptyToken(TYPE);
+            failEmptyToken(TYPE_STRING);
         }
 
         this.requireSlash();
 
         if (type.isEmpty()) {
-            this.failEmptyToken(TYPE);
+            this.failEmptyToken(TYPE_STRING);
         }
 
         return type;
     }
+
+    final static CharPredicate TYPE = RFC2045TOKEN;
 
     private void requireSlash() {
         if (!this.hasMoreCharacters()) {
@@ -150,7 +152,7 @@ abstract class MediaTypeHeaderParser extends HeaderParserWithParameters<MediaTyp
         return subType;
     }
 
-    private final static CharPredicate SUB_TYPE = RFC2045TOKEN.andNot(
+    final static CharPredicate SUB_TYPE = RFC2045TOKEN.andNot(
             CharPredicates.any("+;")
     );
 
@@ -178,7 +180,7 @@ abstract class MediaTypeHeaderParser extends HeaderParserWithParameters<MediaTyp
         return Optional.ofNullable(suffix);
     }
 
-    private final static CharPredicate SUFFIX = RFC2045TOKEN.andNot(
+    final static CharPredicate SUFFIX = RFC2045TOKEN.andNot(
             CharPredicates.any(";")
     );
 
@@ -190,7 +192,7 @@ abstract class MediaTypeHeaderParser extends HeaderParserWithParameters<MediaTyp
     final static String MEDIATYPE = "media type";
 
     private final static char SLASH = '/';
-    private final static String TYPE = "type";
+    private final static String TYPE_STRING = "type";
     private final static String SUBTYPE = "sub type";
 
     @Override

--- a/src/test/java/walkingkooka/net/header/HttpHeaderNameTest.java
+++ b/src/test/java/walkingkooka/net/header/HttpHeaderNameTest.java
@@ -335,7 +335,10 @@ final public class HttpHeaderNameTest extends HeaderName2TestCase<HttpHeaderName
                 Accept.with(
                         list(
                                 MediaType.with("text", "html"),
-                                MediaType.with("application", "xhtml+xml")
+                                MediaType.with("application", "xhtml")
+                                        .setSuffix(
+                                                Optional.of("xml")
+                                        )
                         )
                 )
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/587
- MediaType factory & setters should validate String using parser CharPredicate