### PR TITLE
HeaderHandler.contentDispositionFilenameXXX

### DIFF
--- a/src/main/java/walkingkooka/net/header/ContentDispositionParameterName.java
+++ b/src/main/java/walkingkooka/net/header/ContentDispositionParameterName.java
@@ -88,14 +88,18 @@ final public class ContentDispositionParameterName<V> extends HeaderParameterNam
     /**
      * A {@link ContentDispositionParameterName} holding <code>filename</code>
      */
-    public final static ContentDispositionParameterName<ContentDispositionFileName> FILENAME = CONSTANTS.register("filename",
-            ContentDispositionFileNameNotEncodedHeaderHandler.INSTANCE);
+    public final static ContentDispositionParameterName<ContentDispositionFileName> FILENAME = CONSTANTS.register(
+            "filename",
+            HeaderHandler.contentDispositionFilenameNotEncoded()
+    );
 
     /**
      * A {@link ContentDispositionParameterName} holding <code>filename*</code>
      */
-    public final static ContentDispositionParameterName<ContentDispositionFileName> FILENAME_STAR = CONSTANTS.register("filename*",
-            HeaderHandler.contentDispositionFilename());
+    public final static ContentDispositionParameterName<ContentDispositionFileName> FILENAME_STAR = CONSTANTS.register(
+            "filename*",
+            HeaderHandler.contentDispositionFilenameEncoded()
+    );
 
     /**
      * A {@link ContentDispositionParameterName} holding <code>modification-date</code>

--- a/src/main/java/walkingkooka/net/header/HeaderHandler.java
+++ b/src/main/java/walkingkooka/net/header/HeaderHandler.java
@@ -111,8 +111,15 @@ abstract class HeaderHandler<T> {
     /**
      * {@see ContentDispositionFileNameEncodedHeaderHandler}
      */
-    static HeaderHandler<ContentDispositionFileName> contentDispositionFilename() {
+    static HeaderHandler<ContentDispositionFileName> contentDispositionFilenameEncoded() {
         return ContentDispositionFileNameEncodedHeaderHandler.INSTANCE;
+    }
+
+    /**
+     * {@see ContentDispositionFileNameNotEncodedHeaderHandler}
+     */
+    static HeaderHandler<ContentDispositionFileName> contentDispositionFilenameNotEncoded() {
+        return ContentDispositionFileNameNotEncodedHeaderHandler.INSTANCE;
     }
 
     /**


### PR DESCRIPTION
- Previously ContentDispositionFileNameNotEncodedHeaderHandler.INSTANCE was referenced directly.