### PR TITLE
MediaType.requireContentType message omits parameters

### DIFF
--- a/src/main/java/walkingkooka/net/header/MediaType.java
+++ b/src/main/java/walkingkooka/net/header/MediaType.java
@@ -606,10 +606,10 @@ final public class MediaType extends HeaderWithParameters2<MediaType, MediaTypeP
      */
     public void requireContentType(final MediaType mediaType) {
         if (null == mediaType) {
-            throw new IllegalArgumentException(HttpHeaderName.CONTENT_TYPE + ": Missing required " + this);
+            throw new IllegalArgumentException(HttpHeaderName.CONTENT_TYPE + ": Missing required " + this.clearParameters());
         }
         if (false == this.test(mediaType)) {
-            throw new IllegalArgumentException(HttpHeaderName.CONTENT_TYPE + ": Got " + mediaType + " require " + this);
+            throw new IllegalArgumentException(HttpHeaderName.CONTENT_TYPE + ": Got " + mediaType + " require " + this.clearParameters());
         }
     }
 

--- a/src/test/java/walkingkooka/net/header/MediaTypeTest.java
+++ b/src/test/java/walkingkooka/net/header/MediaTypeTest.java
@@ -1178,6 +1178,20 @@ final public class MediaTypeTest extends HeaderWithParametersTestCase<MediaType,
         );
     }
 
+    @Test
+    public void testRequireContentTypeRemovesParametersMissingFails() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8)
+                .requireContentType(null)
+        );
+
+        this.checkEquals(
+            "Content-Type: Missing required text/plain",
+            thrown.getMessage()
+        );
+    }
+
     // toHeaderText.....................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/730
- MediaType.requireContentType message mediaTypes should not include parameters.