### PR TITLE
Accept.testOrFail message omits parameters

### DIFF
--- a/src/main/java/walkingkooka/net/header/Accept.java
+++ b/src/main/java/walkingkooka/net/header/Accept.java
@@ -22,6 +22,7 @@ import walkingkooka.collect.list.Lists;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html"></a>
@@ -187,8 +188,21 @@ public final class Accept extends Header2<List<MediaType>> implements Predicate<
 
             // Accept: Got text/plain require text/json
             throw new IllegalArgumentException(
-                HttpHeaderName.ACCEPT + ": Got " + this + " require " + mediaType
+                HttpHeaderName.ACCEPT + ": Got " + this.mediaTypesWithoutParameters() + " require " + mediaType.clearParameters()
             );
         }
     }
+
+    private String mediaTypesWithoutParameters() {
+        if (null == this.mediaTypesWithoutParameters) {
+            this.mediaTypesWithoutParameters = this.value()
+                .stream()
+                .map(m -> m.clearParameters().toString())
+                .collect(Collectors.joining(SEPARATOR));
+        }
+
+        return this.mediaTypesWithoutParameters;
+    }
+
+    private String mediaTypesWithoutParameters;
 }

--- a/src/test/java/walkingkooka/net/header/AcceptTest.java
+++ b/src/test/java/walkingkooka/net/header/AcceptTest.java
@@ -176,6 +176,38 @@ public final class AcceptTest extends Header2TestCase<Accept, List<MediaType>>
         );
     }
 
+    @Test
+    public void testTestOrFailMessageOmitsParametersFails() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> Accept.parse("text/html;charset=UTF8, text/json;charset=UTF8;")
+                .testOrFail(
+                    MediaType.TEXT_PLAIN
+                )
+        );
+
+        this.checkEquals(
+            "Accept: Got text/html, text/json require text/plain",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testTestOrFailMessageOmitsParametersFails2() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> Accept.parse("text/html, text/json;")
+                .testOrFail(
+                    MediaType.TEXT_PLAIN.setCharset(CharsetName.UTF_8)
+                )
+        );
+
+        this.checkEquals(
+            "Accept: Got text/html, text/json require text/plain",
+            thrown.getMessage()
+        );
+    }
+
     // toString.........................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/729
- Accept.testOrFail require MediaType should not include parameters.