### PR TITLE
UrlPath without leading slash parent FIX

### DIFF
--- a/src/main/java/walkingkooka/net/UrlPathEmpty.java
+++ b/src/main/java/walkingkooka/net/UrlPathEmpty.java
@@ -57,7 +57,7 @@ final class UrlPathEmpty extends UrlPath {
         return unnormalized(
             name.value(),
             name,
-            Optional.of(parent)
+            Optional.empty() // UrlPathEMPTY + name + nae
         );
     }
 

--- a/src/main/java/walkingkooka/net/UrlPathLeaf.java
+++ b/src/main/java/walkingkooka/net/UrlPathLeaf.java
@@ -70,7 +70,7 @@ abstract class UrlPathLeaf extends UrlPath {
     UrlPath appendTo(final UrlPathLeaf leaf) {
         final UrlPathName name = this.name;
 
-        return this.parent.get()
+        return this.parent.orElse(UrlPath.EMPTY)
             .appendTo(leaf)
             .append(name);
     }
@@ -123,8 +123,10 @@ abstract class UrlPathLeaf extends UrlPath {
 
     @Override
     void gatherPathNames(final List<UrlPathName> names) {
-        this.parent.get()
-            .gatherPathNames(names);
+        final UrlPath parent = this.parent.orElse(null);
+        if (null != parent) {
+            parent.gatherPathNames(names);
+        }
 
         names.add(this.name);
     }

--- a/src/main/java/walkingkooka/net/UrlPathRoot.java
+++ b/src/main/java/walkingkooka/net/UrlPathRoot.java
@@ -79,7 +79,14 @@ final class UrlPathRoot extends UrlPath {
 
     @Override
     UrlPath appendPath(final UrlPath path) {
-        return path;
+        return path.isRoot() || path.isEmpty() ?
+            this :
+            path.value()
+                .startsWith(SEPARATOR_STRING) ?
+                path :
+                parse(
+                    SEPARATOR_STRING + path.value()
+                );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRouting.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpRequestAttributeRouting.java
@@ -132,7 +132,7 @@ final public class HttpRequestAttributeRouting implements Builder<Map<HttpReques
         HttpRequestAttributeRouting that = this;
 
         int i = 0;
-        for (UrlPathName name : path) {
+        for (UrlPathName name : UrlPath.ROOT.append(path)) {
             if (0 != i) {
                 if (UrlPathName.WILDCARD.equals(name)) {
                     that = that.pathComponent(i, HttpRequestAttributeRoutingWildcardPredicate.INSTANCE);

--- a/src/test/java/walkingkooka/net/UrlPathEmptyTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathEmptyTest.java
@@ -20,6 +20,8 @@ package walkingkooka.net;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 public final class UrlPathEmptyTest extends UrlPathTestCase<UrlPathEmpty> {
 
     @Test
@@ -74,6 +76,44 @@ public final class UrlPathEmptyTest extends UrlPathTestCase<UrlPathEmpty> {
             name,
             unnormalized("2", name),
             "2"
+        );
+    }
+
+    // appendPath.......................................................................................................
+
+    @Test
+    public void testAppendPathWithEmpty() {
+        assertSame(
+            UrlPathEmpty.EMPTY_URL_PATH,
+            UrlPathEmpty.EMPTY_URL_PATH.append(UrlPathEmpty.EMPTY_URL_PATH)
+        );
+    }
+
+    @Test
+    public void testAppendPathWithRoot() {
+        assertSame(
+            UrlPath.ROOT,
+            UrlPathEmpty.EMPTY_URL_PATH.append(UrlPath.ROOT)
+        );
+    }
+
+    @Test
+    public void testAppendPathWithSlashPath() {
+        final UrlPath path = UrlPath.parse("/p1/p2");
+
+        assertSame(
+            path,
+            UrlPathEmpty.EMPTY_URL_PATH.append(path)
+        );
+    }
+
+    @Test
+    public void testAppendPathWithPath() {
+        final UrlPath path = UrlPath.parse("p1/p2");
+
+        assertSame(
+            path,
+            UrlPathEmpty.EMPTY_URL_PATH.append(path)
         );
     }
 

--- a/src/test/java/walkingkooka/net/UrlPathRootTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathRootTest.java
@@ -20,6 +20,8 @@ package walkingkooka.net;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
 
     @Test
@@ -74,6 +76,50 @@ public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
             name,
             normalized("/2", name),
             "/2"
+        );
+    }
+
+    // appendPath.......................................................................................................
+
+    @Test
+    public void testAppendPathEmptyPath() {
+        assertSame(
+            UrlPathRoot.ROOT,
+            UrlPathRoot.ROOT.append(UrlPath.EMPTY)
+        );
+    }
+
+    @Test
+    public void testAppendPathNotEmptySlashPath() {
+        final UrlPath path = UrlPath.parse("/a1");
+
+        assertSame(
+            path,
+            UrlPathRoot.ROOT.append(path)
+        );
+    }
+
+    @Test
+    public void testAppendPathNotEmptyPath() {
+        final UrlPath path = UrlPath.parse("a1");
+
+        appendPathAndCheck(
+            UrlPath.ROOT,
+            path,
+            UrlPath.normalized(
+                "/a1",
+                UrlPathName.with("a1"),
+                UrlPath.ROOT_PARENT
+            )
+        );
+    }
+
+    private void appendPathAndCheck(final UrlPath path,
+                                    final UrlPath append,
+                                    final UrlPath expected) {
+        this.checkEquals(
+            expected,
+            path.appendPath(append)
         );
     }
 

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -68,7 +68,8 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
         this.appendNameAndCheck(
             UrlPath.ROOT,
             UrlPathName.ROOT,
-            "//"
+            "//",
+            UrlPath.ROOT
         );
     }
 
@@ -77,16 +78,26 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
         this.appendNameAndCheck(
             UrlPath.ROOT,
             a1(),
-            "/a1"
+            "/a1",
+            UrlPath.ROOT
         );
     }
 
     @Test
     public void testAppendNameEmptyToLeaf() {
         this.appendNameAndCheck(
-            UrlPath.unnormalized("/a1", a1(), UrlPath.ROOT_PARENT),
+            UrlPath.unnormalized(
+                "/a1",
+                a1(),
+                UrlPath.ROOT_PARENT
+            ),
             UrlPathName.ROOT,
-            "/a1//"
+            "/a1//",
+            UrlPath.unnormalized(
+                "/a1",
+                UrlPathName.with("a1"),
+                UrlPath.ROOT_PARENT
+            )
         );
     }
 
@@ -99,16 +110,46 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
                 UrlPath.ROOT_PARENT
             ),
             b2(),
-            "/a1/b2");
+            "/a1/b2",
+            UrlPath.unnormalized(
+                "/a1",
+                UrlPathName.with("a1"),
+                UrlPath.ROOT_PARENT
+            )
+        );
     }
 
     private void appendNameAndCheck(final UrlPath path,
                                     final UrlPathName name,
                                     final String value) {
+        this.appendNameAndCheck(
+            path,
+            name,
+            value,
+            UrlPath.NO_PARENT
+        );
+    }
+
+    private void appendNameAndCheck(final UrlPath path,
+                                    final UrlPathName name,
+                                    final String value,
+                                    final UrlPath parent) {
+        this.appendNameAndCheck(
+            path,
+            name,
+            value,
+            Optional.of(parent)
+        );
+    }
+
+    private void appendNameAndCheck(final UrlPath path,
+                                    final UrlPathName name,
+                                    final String value,
+                                    final Optional<UrlPath> parent) {
         final UrlPath appended = path.append(name);
         this.valueCheck(appended, value);
         this.nameCheck(appended, name);
-        this.parentCheck(appended, path);
+        this.parentCheck(appended, parent);
     }
 
     // appendPath.......................................................................................................
@@ -155,9 +196,9 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
 
     @Test
     public void testAppendPathEmptyToRoot() {
-        this.appendPathAndCheck(
+        assertSame(
             UrlPath.ROOT,
-            UrlPath.EMPTY
+            UrlPath.ROOT.append(UrlPath.EMPTY)
         );
     }
 
@@ -642,10 +683,7 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
             path,
             "without-leading-slash"
         );
-        this.parentCheck(
-            path,
-            UrlPath.EMPTY
-        );
+        this.parentAbsentCheck(path);
     }
 
     @Test
@@ -659,10 +697,7 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
             parent,
             "without"
         );
-        this.parentCheck(
-            parent,
-            UrlPath.EMPTY
-        );
+        this.parentAbsentCheck(parent);
     }
 
     @Test
@@ -868,7 +903,7 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     }
 
     @Test
-    public void testNamesListWhenMultipleComponents() {
+    public void testNamesListWhenSlashMultipleComponents() {
         this.namesListAndCheck(
             "/dir1/dir2/file3",
             "",
@@ -879,10 +914,47 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     }
 
     @Test
-    public void testNamesListWhenMultipleComponentsUnnormalized() {
+    public void testNamesListWhenSlashMultipleComponentsUnnormalized() {
         this.namesListAndCheck(
             "/dir1/dir2/../file3",
             "",
+            "dir1",
+            "dir2",
+            "..",
+            "file3"
+        );
+    }
+
+    @Test
+    public void testNamesListWhenEmpty() {
+        this.namesListAndCheck(
+            UrlPath.parse(""),
+            UrlPathName.EMPTY
+        );
+    }
+
+    @Test
+    public void testNamesListWithOneComponent() {
+        this.namesListAndCheck(
+            "dir1",
+            "dir1"
+        );
+    }
+
+    @Test
+    public void testNamesListWhenMultipleComponents() {
+        this.namesListAndCheck(
+            "dir1/dir2/file3",
+            "dir1",
+            "dir2",
+            "file3"
+        );
+    }
+
+    @Test
+    public void testNamesListWhenMultipleComponentsUnnormalized() {
+        this.namesListAndCheck(
+            "dir1/dir2/../file3",
             "dir1",
             "dir2",
             "..",


### PR DESCRIPTION
- Previously paths without a leading slash would return UrlPath.EMPTY as their root, now the first component is the root.