### PR TITLE
UrlPathName.with verify characters

### DIFF
--- a/src/main/java/walkingkooka/net/UrlPathName.java
+++ b/src/main/java/walkingkooka/net/UrlPathName.java
@@ -19,6 +19,8 @@ package walkingkooka.net;
 
 import walkingkooka.InvalidTextLengthException;
 import walkingkooka.naming.Name;
+import walkingkooka.predicate.character.CharPredicate;
+import walkingkooka.predicate.character.CharPredicates;
 import walkingkooka.text.CaseSensitivity;
 import walkingkooka.text.CharSequences;
 
@@ -78,12 +80,25 @@ public final class UrlPathName extends NetName implements Comparable<UrlPathName
     }
 
     private static UrlPathName nonConstant(final String name) {
-        if (name.length() > MAXIMUM_LENGTH) {
-            throw new InvalidTextLengthException("url path", name, 0, MAXIMUM_LENGTH);
-        }
+        CharPredicates.failIfNullOrEmptyOrInitialAndPartFalse(
+            name,
+            "path",
+            CHARS,
+            CHARS
+        );
+
+        InvalidTextLengthException.throwIfFail(
+            "path",
+            name,
+            1,
+            MAXIMUM_LENGTH
+        );
 
         return new UrlPathName(name);
     }
+
+    private final static CharPredicate CHARS = CharPredicates.is(UrlPath.SEPARATOR_CHAR)
+        .negate();
 
     /**
      * Private constructor

--- a/src/test/java/walkingkooka/net/UrlPathNameTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNameTest.java
@@ -51,6 +51,14 @@ public final class UrlPathNameTest implements ClassTesting2<UrlPathName>,
         assertThrows(InvalidTextLengthException.class, () -> UrlPathName.with(new String(chars)));
     }
 
+    @Test
+    public void testWithSlashesFails() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> UrlPathName.with("dd/mm/yyyy")
+        );
+    }
+
     // Comparable.......................................................................................................
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/803
- UrlPathName.with should verify characters and fail it slash is included