### PR TITLE
EmailAddress.parse empty String throws EmptyTextException

### DIFF
--- a/src/main/java/walkingkooka/net/email/EmailAddressParser.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParser.java
@@ -36,6 +36,17 @@ abstract class EmailAddressParser {
     final EmailAddress parse(final String email) {
         Objects.requireNonNull(email, "email");
 
+        final EmailAddress emailAddress;
+        if (email.isEmpty()) {
+            this.emptyText();
+            emailAddress = null;
+        } else {
+            emailAddress = this.parseNotEmpty(email);
+        }
+        return emailAddress;
+    }
+
+    private EmailAddress parseNotEmpty(final String email) {
         EmailAddress emailAddress = null;
 
         Exit:
@@ -149,6 +160,11 @@ abstract class EmailAddressParser {
         .build();
 
     private final static CharPredicate QUOTABLE_USERNAME_CHARACTERS = CharPredicates.any(" <>[]:;@\\");
+
+    /**
+     * Handles an empty string input.
+     */
+    abstract void emptyText();
 
     /**
      * Email too long.

--- a/src/main/java/walkingkooka/net/email/EmailAddressParserTryParse.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParserTryParse.java
@@ -37,6 +37,11 @@ final class EmailAddressParserTryParse extends EmailAddressParser {
     }
 
     @Override
+    void emptyText() {
+        // nop
+    }
+
+    @Override
     void emailTooLong(final String email) {
         // nop
     }

--- a/src/main/java/walkingkooka/net/email/EmailAddressParserWith.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParserWith.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.email;
 
+import walkingkooka.EmptyTextException;
 import walkingkooka.InvalidCharacterException;
 import walkingkooka.InvalidTextLengthException;
 
@@ -35,6 +36,11 @@ final class EmailAddressParserWith extends EmailAddressParser {
 
     private EmailAddressParserWith() {
         super();
+    }
+
+    @Override
+    void emptyText() {
+        throw new EmptyTextException(EmailAddress.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/email/EmailAddressTest.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressTest.java
@@ -19,6 +19,7 @@ package walkingkooka.net.email;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import walkingkooka.EmptyTextException;
 import walkingkooka.InvalidCharacterException;
 import walkingkooka.InvalidTextLengthException;
 import walkingkooka.ToStringTesting;
@@ -53,6 +54,14 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
         assertThrows(
             NullPointerException.class,
             () -> EmailAddress.tryParse(null)
+        );
+    }
+
+    @Test
+    public void testParseEmptyStringFails() {
+        this.parseStringFails2(
+            "",
+            new EmptyTextException("EmailAddress")
         );
     }
 


### PR DESCRIPTION
- Previously would complain about missing host which is poor.