### PR TITLE
EmailAddress.parse remove input text from most messages

### DIFF
--- a/src/main/java/walkingkooka/net/email/EmailAddress.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddress.java
@@ -20,7 +20,6 @@ package walkingkooka.net.email;
 import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.net.HostAddress;
-import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.marshall.JsonNodeContext;
@@ -67,15 +66,15 @@ final public class EmailAddress implements HasText,
     /**
      * Message when an email is missing a user.
      */
-    static String missingUser(final String address) {
-        return "Email missing user=" + CharSequences.quote(address);
+    static String missingUser() {
+        return "Email missing user";
     }
 
     /**
      * Message when an email is missing a host.
      */
-    static String missingHost(final String address) {
-        return "Email missing host=" + CharSequences.quote(address);
+    static String missingHost() {
+        return "Email missing host";
     }
 
     /**

--- a/src/main/java/walkingkooka/net/email/EmailAddressParser.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParser.java
@@ -116,16 +116,19 @@ abstract class EmailAddressParser {
                     }
                     userNameCharacterCount += charactersSinceDot;
                     if (0 == userNameCharacterCount) {
-                        this.missingUser(email);
+                        this.missingUser();
                         break Exit;
                     }
                     // if @ is the last character complain because host is missing.
                     if ((length - 1) == i) {
-                        this.missingHost(email);
+                        this.missingHost();
                         break Exit;
                     }
                     if (userNameCharacterCount >= EmailAddress.MAX_LOCAL_LENGTH) {
-                        this.userNameTooLong(userNameCharacterCount, email);
+                        this.userNameTooLong(
+                            userNameCharacterCount,
+                            email
+                        );
                         break Exit;
                     }
                     user = email.substring(0, i);
@@ -142,7 +145,7 @@ abstract class EmailAddressParser {
                 break Exit;
             }
             if (null == hostAddress) {
-                this.missingHost(email);
+                this.missingHost();
                 break;
             }
             emailAddress = EmailAddress.with0(email, user, hostAddress);
@@ -174,17 +177,18 @@ abstract class EmailAddressParser {
     /**
      * Message when an email is missing a user.
      */
-    abstract void missingUser(final String email);
+    abstract void missingUser();
 
     /**
      * Message when a user name is too long.
      */
-    abstract void userNameTooLong(final int length, final String email);
+    abstract void userNameTooLong(final int length,
+                                  final String email);
 
     /**
      * Message when an email is missing a host.
      */
-    abstract void missingHost(final String email);
+    abstract void missingHost();
 
     /**
      * Message when an email contains an invalid character

--- a/src/main/java/walkingkooka/net/email/EmailAddressParserTryParse.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParserTryParse.java
@@ -47,17 +47,18 @@ final class EmailAddressParserTryParse extends EmailAddressParser {
     }
 
     @Override
-    void missingUser(final String email) {
+    void missingUser() {
         // nop
     }
 
     @Override
-    void userNameTooLong(final int length, final String email) {
+    void userNameTooLong(final int length,
+                         final String email) {
         // nop
     }
 
     @Override
-    void missingHost(final String email) {
+    void missingHost() {
         // nop
     }
 

--- a/src/main/java/walkingkooka/net/email/EmailAddressParserWith.java
+++ b/src/main/java/walkingkooka/net/email/EmailAddressParserWith.java
@@ -49,18 +49,28 @@ final class EmailAddressParserWith extends EmailAddressParser {
     }
 
     @Override
-    void missingUser(final String email) {
-        this.fail(EmailAddress.missingUser(email));
+    void missingUser() {
+        this.fail(
+            EmailAddress.missingUser()
+        );
     }
 
     @Override
-    void userNameTooLong(final int length, final String email) {
-        throw new InvalidTextLengthException("Email username", email, 0, EmailAddress.MAX_LOCAL_LENGTH);
+    void userNameTooLong(final int length,
+                         final String email) {
+        throw new InvalidTextLengthException(
+            "Email username",
+            email,
+            0,
+            EmailAddress.MAX_LOCAL_LENGTH
+        );
     }
 
     @Override
-    void missingHost(final String email) {
-        this.fail(EmailAddress.missingHost(email));
+    void missingHost() {
+        this.fail(
+            EmailAddress.missingHost()
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/email/EmailAddressTest.java
+++ b/src/test/java/walkingkooka/net/email/EmailAddressTest.java
@@ -132,6 +132,32 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
     }
 
     @Test
+    public void testParseMissingUser() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> EmailAddress.parse("@example.com")
+        );
+
+        this.checkEquals(
+            "Email missing user",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
+    public void testParseMissingHost() {
+        final IllegalArgumentException thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> EmailAddress.parse("user@")
+        );
+
+        this.checkEquals(
+            "Email missing host",
+            thrown.getMessage()
+        );
+    }
+
+    @Test
     public void testServerContainsInvalidCharacterFails() {
         final String email = "user@s erver";
         this.parseStringFails2(email, new InvalidCharacterException(email, email.lastIndexOf(' ')));
@@ -145,14 +171,18 @@ final public class EmailAddressTest implements ClassTesting2<EmailAddress>,
 
     @Test
     public void testWithoutUserFails() {
-        final String email = "@server";
-        this.parseStringFails2(email, EmailAddress.missingUser(email));
+        this.parseStringFails2(
+            "@server",
+            EmailAddress.missingUser()
+        );
     }
 
     @Test
     public void testWithoutHostFails() {
-        final String email = "user@";
-        this.parseStringFails2(email, EmailAddress.missingHost(email));
+        this.parseStringFails2(
+            "user@",
+            EmailAddress.missingHost()
+        );
     }
 
     @Test


### PR DESCRIPTION
- Removed input email address from some messages.
- Motivated by EmailAddressValidator which does not require text to be repeated in error messages.