### PR TITLE
Path.normalize percent-encoded-lower-case-digits & unnecessary encodings

### DIFF
--- a/src/main/java/walkingkooka/net/UrlPath.java
+++ b/src/main/java/walkingkooka/net/UrlPath.java
@@ -176,12 +176,12 @@ public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
 
         return this.appendName(
             name,
-            this
+            false // unknown if name is normalized assume unnormalized
         );
     }
 
     abstract UrlPath appendName(final UrlPathName name,
-                                final UrlPath parent);
+                                final boolean normalizedName);
 
     @Override
     public final UrlPath append(final UrlPath path) {
@@ -214,6 +214,8 @@ public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
      * <li>An empty path is replaced with "/"</li>
      * <li>Dot segments <code>.</code> are removed</li>
      * <li>Double dot segments <code>..</code> cause the parent to be removed</li>
+     * <li>Percent encoded characters are encoded to UPPER-CASE HEX DIGITS</li>
+     * <li>Characters that do not require percent encoding must be decoded</li>
      * </ul>
      * <br>
      * <a href="https://en.wikipedia.org/wiki/URI_normalization">URI normalization</a>
@@ -226,6 +228,14 @@ public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
      *
      * Removing duplicate slashes Paths which include two adjacent slashes could be converted to one. Example:
      * http://example.com/foo//bar.html → http://example.com/foo/bar.html
+     *
+     * Decoding percent-encoded triplets of unreserved characters. Percent-encoded triplets of the URI in the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E)
+     * do not require percent-encoding and should be decoded to their corresponding unreserved characters.[4] Example:
+     *
+     * Normalizations that preserve semantics
+     * The following normalizations are described in RFC 3986 [1] to result in equivalent URIs:
+     *
+     * Converting percent-encoded triplets to uppercase. The hexadecimal digits within a percent-encoding triplet of the URI (e.g., %3a versus %3A) are case-insensitive and therefore should be normalized to use uppercase letters for the digits A-F.[2
      * </pre>
      */
     public abstract UrlPath normalize();
@@ -289,7 +299,6 @@ public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
     public final boolean equals(final Object other) {
         return this == other ||
             other instanceof UrlPath &&
-                this.getClass() == other.getClass() &&
                 this.equals0((UrlPath) other);
     }
 

--- a/src/main/java/walkingkooka/net/UrlPathEmpty.java
+++ b/src/main/java/walkingkooka/net/UrlPathEmpty.java
@@ -52,7 +52,7 @@ final class UrlPathEmpty extends UrlPath {
 
     @Override
     UrlPath appendName(final UrlPathName name,
-                       final UrlPath parent) {
+                       final boolean nameNormalized) {
         return unnormalized(
             name.value(),
             name,

--- a/src/main/java/walkingkooka/net/UrlPathName.java
+++ b/src/main/java/walkingkooka/net/UrlPathName.java
@@ -255,13 +255,266 @@ public final class UrlPathName extends NetName implements Comparable<UrlPathName
     }
 
     /**
-     * Returns true if this name is normalized.
+     * Handles normalizing path components that include lower-cased percent encoded characters or characters that were
+     * unnecessarily percent-encoded. DOT and DOUBLE DOT must be tested and handled before calling this method.
      */
-    boolean isNormalized() {
+    UrlPath normalize(final UrlPath parent) {
         final String name = this.name;
-        return name.length() != 0 &&
-            false == name.equals(".") &&
-            false == name.equals("..");
+
+        final UrlPath normalizedPath;
+
+        switch (name) {
+            case "":
+                normalizedPath = parent.appendName(
+                    this,
+                    true // normalized, needed to support trailing slashes
+                );
+                break;
+            case ".":
+                normalizedPath = parent;
+                break;
+            case "..":
+                normalizedPath = parent.parentOrSelf();
+                break;
+            default:
+                final int length = name.length();
+
+                final int MODE_CHAR = 1;
+                final int MODE_ESCAPED_FIRST = 2;
+                final int MODE_ESCAPED_SECOND = 3;
+
+                int mode = MODE_CHAR;
+
+                final StringBuilder b = new StringBuilder();
+                boolean normalized = true;
+
+                int percentEscapedCharValue = 0;
+                char firstEscapedChar = 0;
+                char secondEscapedChar = 0;
+                boolean percentNormalized = false;
+
+                for (int i = 0; i < length; i++) {
+                    final char c = name.charAt(i);
+
+                    switch (mode) {
+                        case MODE_CHAR:
+                            switch (c) {
+                                case '%':
+                                    mode = MODE_ESCAPED_FIRST;
+                                    break;
+                                default:
+                                    b.append(c);
+                                    break;
+                            }
+                            break;
+                        case MODE_ESCAPED_FIRST:
+                            switch (c) {
+                                case '0':
+                                case '1':
+                                case '2':
+                                case '3':
+                                case '4':
+                                case '5':
+                                case '6':
+                                case '7':
+                                case '8':
+                                case '9':
+                                    percentEscapedCharValue = c - '0';
+                                    firstEscapedChar = c;
+                                    percentNormalized = false;
+                                    mode = MODE_ESCAPED_SECOND;
+                                    break;
+                                case 'A':
+                                case 'B':
+                                case 'C':
+                                case 'D':
+                                case 'E':
+                                case 'F':
+                                case 'G':
+                                    percentEscapedCharValue = c - 'a' + 10;
+                                    firstEscapedChar = c;
+                                    percentNormalized = false;
+                                    mode = MODE_ESCAPED_SECOND;
+                                    break;
+                                case 'a':
+                                case 'b':
+                                case 'c':
+                                case 'd':
+                                case 'e':
+                                case 'f':
+                                case 'g':
+                                    percentEscapedCharValue = c - 'a' + 10;
+                                    firstEscapedChar = Character.toUpperCase(c);
+                                    percentNormalized = true;
+                                    normalized = true;
+                                    mode = MODE_ESCAPED_SECOND;
+                                    break;
+                                default:
+                                    b.append(c);
+                                    mode = MODE_CHAR;
+                                    break;
+                            }
+                            break;
+                        case MODE_ESCAPED_SECOND:
+                            switch (c) {
+                                case '0':
+                                case '1':
+                                case '2':
+                                case '3':
+                                case '4':
+                                case '5':
+                                case '6':
+                                case '7':
+                                case '8':
+                                case '9':
+                                    percentEscapedCharValue = percentEscapedCharValue * 16 + c - '0';
+                                    secondEscapedChar = c;
+                                    break;
+                                case 'A':
+                                case 'B':
+                                case 'C':
+                                case 'D':
+                                case 'E':
+                                case 'F':
+                                case 'G':
+                                    percentEscapedCharValue = percentEscapedCharValue * 16 + c - 'a' + 10;
+                                    secondEscapedChar = c;
+                                    break;
+                                case 'a':
+                                case 'b':
+                                case 'c':
+                                case 'd':
+                                case 'e':
+                                case 'f':
+                                case 'g':
+                                    percentEscapedCharValue = percentEscapedCharValue * 16 + c - 'a' + 10;
+                                    secondEscapedChar = Character.toUpperCase(c);
+                                    percentNormalized = true;
+                                    break;
+                                default:
+                                    b.append(c);
+                                    mode = MODE_CHAR;
+                                    break;
+                            }
+                            if (MODE_ESCAPED_SECOND == mode) {
+                                final char percentEscapedChar = (char) percentEscapedCharValue;
+                                if (shouldNeverPercentEncoded(percentEscapedChar)) {
+                                    b.append(percentEscapedChar);
+                                    normalized = true;
+                                } else {
+                                    normalized = percentNormalized;
+                                    b.append(firstEscapedChar);
+                                    b.append(secondEscapedChar);
+                                }
+
+                                mode = MODE_CHAR;
+                            }
+                            break;
+                        default:
+                            NeverError.unhandledCase(
+                                mode,
+                                MODE_CHAR, MODE_ESCAPED_FIRST, MODE_ESCAPED_SECOND
+                            );
+                            break;
+                    }
+                }
+
+                normalizedPath = parent.appendName(
+                    normalized ?
+                        with(
+                            b.toString()
+                        ) :
+                        this,
+                    true // normalized
+                );
+                break;
+        }
+
+        return normalizedPath;
+    }
+
+    /**
+     * Tests if the given character should not be percent-encoded.
+     * <pre>
+     * https://en.wikipedia.org/wiki/URI_normalization
+     * Decoding percent-encoded triplets of unreserved characters.
+     * Percent-encoded triplets of the URI in the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) do not require percent-encoding and should be decoded to their corresponding unreserved characters.
+     * [4] Example: http://example.com/%7Efoo → http://example.com/~foo
+     * </pre>
+     */
+    private static boolean shouldNeverPercentEncoded(final char c) {
+        final boolean never;
+
+        switch (c) {
+            // hyphen (%2D)
+            case '-':
+                // period (%2E)
+            case '.':
+                // underscore (%5F), or tilde (%7E)
+            case '_':
+            case '~':
+                // ALPHA (%41–%5A
+            case 'A':
+            case 'B':
+            case 'C':
+            case 'D':
+            case 'E':
+            case 'F':
+            case 'G':
+            case 'H':
+            case 'I':
+            case 'J':
+            case 'K':
+            case 'L':
+            case 'M':
+            case 'N':
+            case 'O':
+            case 'P':
+            case 'Q':
+            case 'R':
+            case 'S':
+            case 'T':
+            case 'U':
+            case 'V':
+            case 'W':
+            case 'X':
+            case 'Y':
+            case 'Z':
+                // ALPHA %61–%7A)
+            case 'a':
+            case 'b':
+            case 'c':
+            case 'd':
+            case 'e':
+            case 'f':
+            case 'g':
+            case 'h':
+            case 'i':
+            case 'j':
+            case 'k':
+            case 'l':
+            case 'm':
+            case 'n':
+            case 'o':
+            case 'p':
+            case 'q':
+            case 'r':
+            case 's':
+            case 't':
+            case 'u':
+            case 'v':
+            case 'w':
+            case 'x':
+            case 'y':
+            case 'z':
+                never = true;
+                break;
+            default:
+                never = false;
+                break;
+        }
+
+        return never;
     }
 
     // Object...........................................................................................................

--- a/src/main/java/walkingkooka/net/UrlPathNotEmpty.java
+++ b/src/main/java/walkingkooka/net/UrlPathNotEmpty.java
@@ -72,7 +72,10 @@ abstract class UrlPathNotEmpty extends UrlPath {
 
         return this.parent.orElse(UrlPath.EMPTY)
             .appendTo(leaf)
-            .append(name);
+            .appendName(
+                name,
+                this.isNormalized()
+            );
     }
 
     @Override

--- a/src/main/java/walkingkooka/net/UrlPathNotEmptyNormalized.java
+++ b/src/main/java/walkingkooka/net/UrlPathNotEmptyNormalized.java
@@ -38,14 +38,14 @@ final class UrlPathNotEmptyNormalized extends UrlPathNotEmpty {
 
     @Override
     UrlPath appendName(final UrlPathName name,
-                       final UrlPath parent) {
+                       final boolean nameNormalized) {
         final String path = this.path;
         final String nameString = name.value();
 
         final String newPath;
 
         if (nameString.isEmpty()) {
-            newPath = path + SEPARATOR_CHAR + SEPARATOR_CHAR;
+            newPath = path + SEPARATOR_CHAR;
 
         } else {
             if (path.endsWith(SEPARATOR_STRING)) {
@@ -55,18 +55,18 @@ final class UrlPathNotEmptyNormalized extends UrlPathNotEmpty {
             }
         }
 
-        final Optional<UrlPath> parent2 = Optional.of(parent);
+        final Optional<UrlPath> optionalThis = Optional.of(this);
 
-        return name.isNormalized() ?
+        return nameNormalized ?
             new UrlPathNotEmptyNormalized(
                 newPath,
                 name,
-                parent2
+                optionalThis
             ) :
             unnormalized(
                 newPath,
                 name,
-                parent2
+                optionalThis
             );
     }
 

--- a/src/main/java/walkingkooka/net/UrlPathNotEmptyUnnormalized.java
+++ b/src/main/java/walkingkooka/net/UrlPathNotEmptyUnnormalized.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -38,7 +39,7 @@ final class UrlPathNotEmptyUnnormalized extends UrlPathNotEmpty {
 
     @Override
     UrlPath appendName(final UrlPathName name,
-                       final UrlPath parent) {
+                       final boolean nameNormalized) {
         final String path = this.path;
         final String nameString = name.value();
 
@@ -57,7 +58,7 @@ final class UrlPathNotEmptyUnnormalized extends UrlPathNotEmpty {
         return new UrlPathNotEmptyUnnormalized(
             newPath,
             name,
-            Optional.of(parent)
+            Optional.of(this)
         );
     }
 
@@ -74,19 +75,20 @@ final class UrlPathNotEmptyUnnormalized extends UrlPathNotEmpty {
     public UrlPath normalize() {
         UrlPath normalized = ROOT;
 
-        for (final UrlPathName name : this) {
-            switch (name.value()) {
-                case "":
-                    break;
-                case ".":
-                    break;
-                case "..":
-                    normalized = normalized.parentOrSelf();
-                    break;
-                default:
-                    normalized = normalized.append(name);
-                    break;
+        final Collection<UrlPathName> names = this.namesList();
+
+        int i = 0;
+        final int last = names.size() - 1;
+
+        for (final UrlPathName name : names) {
+            if (name.isEmpty()) {
+                if (i != last) {
+                    i++;
+                    continue;
+                }
             }
+            i++;
+            normalized = name.normalize(normalized);
         }
 
         return normalized;

--- a/src/main/java/walkingkooka/net/UrlPathRoot.java
+++ b/src/main/java/walkingkooka/net/UrlPathRoot.java
@@ -57,7 +57,7 @@ final class UrlPathRoot extends UrlPath {
 
     @Override
     UrlPath appendName(final UrlPathName name,
-                       final UrlPath parent) {
+                       final boolean nameNormalized) {
         final String nameString = name.value();
         final String value;
 
@@ -69,11 +69,17 @@ final class UrlPathRoot extends UrlPath {
             value = separatorString + nameString;
         }
 
-        final Optional<UrlPath> parent2 = Optional.of(parent);
-
-        return name.isNormalized() ?
-            UrlPathNotEmptyNormalized.withNormalized(value, name, parent2) :
-            UrlPathNotEmptyUnnormalized.withUnnormalized(value, name, parent2);
+        return nameNormalized ?
+            UrlPathNotEmptyNormalized.withNormalized(
+                value,
+                name,
+                Optional.of(this)
+            ) :
+            UrlPathNotEmptyUnnormalized.withUnnormalized(
+                value,
+                name,
+                Optional.of(this)
+            );
     }
 
     @Override

--- a/src/test/java/walkingkooka/net/UrlPathNotEmptyNormalizedTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNotEmptyNormalizedTest.java
@@ -29,8 +29,8 @@ public final class UrlPathNotEmptyNormalizedTest extends UrlPathTestCase<UrlPath
 
         this.appendNameAndCheck(
             name,
-            unnormalized("/a1/b2//", name),
-            "/a1/b2//"
+            unnormalized("/a1/b2/", name),
+            "/a1/b2/"
         );
     }
 
@@ -92,6 +92,13 @@ public final class UrlPathNotEmptyNormalizedTest extends UrlPathTestCase<UrlPath
     public void testNormalizeStartsWithSlash() {
         this.normalizeAndCheck(
             "/path1/path2"
+        );
+    }
+
+    @Test
+    public void testNormalizeStartsAndTrailingSlash() {
+        this.normalizeAndCheck(
+            "/path1/path2/"
         );
     }
 
@@ -202,9 +209,9 @@ public final class UrlPathNotEmptyNormalizedTest extends UrlPathTestCase<UrlPath
     @Test
     public void testToStringWithSpace() {
         this.toStringAndCheck(
-            UrlPath.parse("/path1/ path2/")
+            UrlPath.parse("/path1/ path2")
                 .normalize(),
-            "/path1/%20path2/"
+            "/path1/%20path2"
         );
     }
 

--- a/src/test/java/walkingkooka/net/UrlPathNotEmptyUnnormalizedTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNotEmptyUnnormalizedTest.java
@@ -99,13 +99,21 @@ public final class UrlPathNotEmptyUnnormalizedTest extends UrlPathTestCase<UrlPa
     @Test
     public void testNormalizeStartsWithSlash() {
         this.normalizeAndCheck(
+            "/path1/.",
+            "/path1"
+        );
+    }
+
+    @Test
+    public void testNormalizeStartsWithSlash2() {
+        this.normalizeAndCheck(
             "/path1/./path2",
             "/path1/path2"
         );
     }
 
     @Test
-    public void testNormalizeStartsWithSlash2() {
+    public void testNormalizeStartsWithSlash3() {
         this.normalizeAndCheck(
             "/path1/../path2",
             "/path2"

--- a/src/test/java/walkingkooka/net/UrlPathRootTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathRootTest.java
@@ -63,7 +63,7 @@ public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
 
         this.appendNameAndCheck(
             name,
-            normalized("/abc", name),
+            unnormalized("/abc", name),
             "/abc"
         );
     }
@@ -74,7 +74,7 @@ public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
 
         this.appendNameAndCheck(
             name,
-            normalized("/2", name),
+            unnormalized("/2", name),
             "/2"
         );
     }
@@ -106,7 +106,7 @@ public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
         appendPathAndCheck(
             UrlPath.ROOT,
             path,
-            UrlPath.normalized(
+            UrlPath.unnormalized(
                 "/a1",
                 UrlPathName.with("a1"),
                 UrlPath.ROOT_PARENT

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -481,6 +481,51 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     }
 
     @Test
+    public void testAppendPathNormalizedToNormalized2() {
+        final UrlPathName c3 = UrlPathName.with("c3");
+        final UrlPathName d4 = UrlPathName.with("d4");
+
+        final UrlPath start = UrlPath.normalized(
+            "/a1/b2",
+            b2(),
+            Optional.of(
+                UrlPath.normalized(
+                    "/a1",
+                    a1(),
+                    UrlPath.EMPTY_PARENT
+                )
+            )
+        );
+        final UrlPath path = UrlPath.normalized(
+            "/c3/d4",
+            d4,
+            Optional.of(
+                UrlPath.normalized(
+                    "/c3",
+                    c3,
+                    UrlPath.EMPTY_PARENT
+                )
+            )
+        );
+
+        this.appendPathAndCheck(
+            start,
+            path,
+            UrlPath.normalized(
+                "/a1/b2/c3/d4",
+                d4,
+                Optional.of(
+                    UrlPath.normalized(
+                        "/a1/b2/c3",
+                        c3,
+                        Optional.of(start)
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
     public void testAppendPathUnnormalizedToNormalized() {
         final UrlPath start = UrlPath.normalized(
             "/a1",
@@ -495,7 +540,7 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
         this.appendPathAndCheck(
             start,
             path,
-            UrlPath.normalized(
+            UrlPath.unnormalized(
                 "/a1/b2",
                 b2(),
                 Optional.of(start)
@@ -529,14 +574,11 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
             appended,
             expected.value()
         );
-        this.parentCheck(
-            appended,
-            path
-        );
+
         this.checkEquals(
             expected.isNormalized(),
             appended.isNormalized(),
-            () -> "normalized " + appended
+            () -> "normalized " + expected + " AND " + appended
         );
 
         this.checkEquals(
@@ -827,6 +869,22 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     @Test
     public void testNormalizeEmptyRemoved() {
         this.normalizeAndCheck(
+            "/a1//",
+            "/a1/"
+        );
+    }
+
+    @Test
+    public void testNormalizeEmptyRemoved2() {
+        this.normalizeAndCheck(
+            "/a1//b2",
+            "/a1/b2"
+        );
+    }
+
+    @Test
+    public void testNormalizeEmptyRemoved3() {
+        this.normalizeAndCheck(
             "/a1//b2/c3",
             "/a1/b2/c3"
         );
@@ -835,13 +893,21 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     @Test
     public void testNormalizeDot() {
         this.normalizeAndCheck(
-            "/a1/b2/./c3",
-            "/a1/b2/c3"
+            "/./a1",
+            "/a1"
         );
     }
 
     @Test
     public void testNormalizeDot2() {
+        this.normalizeAndCheck(
+            "/a1/./b2",
+            "/a1/b2"
+        );
+    }
+
+    @Test
+    public void testNormalizeDot3() {
         this.normalizeAndCheck(
             "/a1/b2/./c3/./d4",
             "/a1/b2/c3/d4"
@@ -885,6 +951,22 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
         this.normalizeAndCheck(
             "/a1/../b2/./c3/d4",
             "/b2/c3/d4"
+        );
+    }
+
+    @Test
+    public void testNormalizeUnnecessaryPercentEncodedCharacter() {
+        this.normalizeAndCheck(
+            "/abc%44%45f",
+            "/abcDEf"
+        );
+    }
+
+    @Test
+    public void testNormalizeLowerCasePercentEncodedCharacter() {
+        this.normalizeAndCheck(
+            "/abc%2adef",
+            "/abc%2Adef"
         );
     }
 

--- a/src/test/java/walkingkooka/net/UrlPathTestCase.java
+++ b/src/test/java/walkingkooka/net/UrlPathTestCase.java
@@ -78,7 +78,8 @@ public abstract class UrlPathTestCase<P extends UrlPath> implements ClassTesting
 
     final void normalizeAndCheck(final String path) {
         this.normalizeAndCheck(
-            UrlPath.parse(path)
+            path,
+            path
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-net/issues/522
- Url normalization Decoding percent-encoded triplets of unreserved characters.

- Closes https://github.com/mP1/walkingkooka-net/issues/521
- Uri normalization lower case percent encoded triplets should be uppercased