### PR TITLE
Revert "https://github.com/mP1/walkingkooka-tree/pull/998 ExpressionF…

### DIFF
--- a/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionEmailAddress.java
+++ b/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionEmailAddress.java
@@ -59,6 +59,6 @@ final class NetExpressionFunctionEmailAddress<C extends ExpressionEvaluationCont
     @Override
     public EmailAddress apply(final List<Object> parameters,
                               final C context) {
-        return EMAIL_ADDRESS.getOrFail(parameters, 0, context);
+        return EMAIL_ADDRESS.getOrFail(parameters, 0);
     }
 }

--- a/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionGetHost.java
+++ b/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionGetHost.java
@@ -60,7 +60,7 @@ final class NetExpressionFunctionGetHost<C extends ExpressionEvaluationContext> 
     @Override
     public HostAddress apply(final List<Object> parameters,
                              final C context) {
-        final HasHostAddress has = HAS_HOST_ADDRESS.getOrFail(parameters, 0, context);
+        final HasHostAddress has = HAS_HOST_ADDRESS.getOrFail(parameters, 0);
 
         return has.hostAddress();
     }

--- a/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionSetHost.java
+++ b/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionSetHost.java
@@ -61,8 +61,8 @@ final class NetExpressionFunctionSetHost<C extends ExpressionEvaluationContext> 
     @Override
     public HasHostAddress apply(final List<Object> parameters,
                                 final C context) {
-        final HasHostAddress has = HAS_HOST_ADDRESS.getOrFail(parameters, 0, context);
-        final HasHostAddress newHost = HAS_HOST_ADDRESS2.getOrFail(parameters, 1, context);
+        final HasHostAddress has = HAS_HOST_ADDRESS.getOrFail(parameters, 0);
+        final HasHostAddress newHost = HAS_HOST_ADDRESS2.getOrFail(parameters, 1);
 
         System.out.println("parameters=" + parameters);
         System.out.println(has + " setHostAddress " + newHost + " " + newHost.hostAddress());

--- a/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionUrl.java
+++ b/src/main/java/walkingkooka/net/expression/function/NetExpressionFunctionUrl.java
@@ -59,6 +59,6 @@ final class NetExpressionFunctionUrl<C extends ExpressionEvaluationContext> exte
     @Override
     public Url apply(final List<Object> parameters,
                      final C context) {
-        return URL.getOrFail(parameters, 0, context);
+        return URL.getOrFail(parameters, 0);
     }
 }


### PR DESCRIPTION
…unctionParameter.defaultValue Function ExpressionEvaluationContext was Optional"

This reverts commit 222c2371124548801fbecfed62a0b56c99828f04.

- includes additional NetExpressionFunctionsTest compile FIX