### PR TITLE
LinkParameterName.toText()

### DIFF
--- a/src/main/java/walkingkooka/net/header/Link.java
+++ b/src/main/java/walkingkooka/net/header/Link.java
@@ -17,7 +17,6 @@
 
 package walkingkooka.net.header;
 
-import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.net.Url;
@@ -194,11 +193,8 @@ final public class Link extends HeaderWithParameters2<Link,
 
             json = json.set(
                 JsonPropertyName.with(name.value()),
-                name.handler.toText(
-                    Cast.to(
-                        parameterNameAndValue.getValue()
-                    ),
-                    name
+                name.toText(
+                    parameterNameAndValue.getValue()
                 )
             );
         }

--- a/src/main/java/walkingkooka/net/header/LinkParameterName.java
+++ b/src/main/java/walkingkooka/net/header/LinkParameterName.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.net.header;
 
+import walkingkooka.Cast;
 import walkingkooka.naming.Name;
 import walkingkooka.net.Url;
 import walkingkooka.net.http.HttpMethod;
@@ -147,6 +148,18 @@ final public class LinkParameterName<V> extends HeaderParameterName<V> implement
     private LinkParameterName(final String value,
                               final HeaderHandler<V> handler) {
         super(value, handler);
+    }
+
+    /**
+     * Helper that is mostly intended for an external json marshaller.
+     */
+    public String toText(final Object value) {
+        return this.handler.toText(
+            Cast.to(
+                value
+            ),
+            this
+        );
     }
 
     // Comparable......................................................................................................


### PR DESCRIPTION
- Helper required by external: BasicJsonMarshallerTypedLink