### PR TITLE
UrlPath implements TreePrintable

### DIFF
--- a/src/main/java/walkingkooka/net/UrlPath.java
+++ b/src/main/java/walkingkooka/net/UrlPath.java
@@ -20,6 +20,8 @@ package walkingkooka.net;
 
 import walkingkooka.naming.Path;
 import walkingkooka.naming.PathSeparator;
+import walkingkooka.text.printer.IndentingPrinter;
+import walkingkooka.text.printer.TreePrintable;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -29,7 +31,8 @@ import java.util.function.Predicate;
  * A {@link Path} which may be part of a {@link Url} after the host and port but before any present query string or anchor.
  */
 public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
-    Comparable<UrlPath> {
+    Comparable<UrlPath>,
+    TreePrintable {
 
     final static char SEPARATOR_CHAR = '/';
 
@@ -312,5 +315,12 @@ public abstract class UrlPath implements Path<UrlPath, UrlPathName>,
     @Override
     public final int compareTo(final UrlPath path) {
         return this.toString().compareTo(path.toString());
+    }
+
+    // TreePrintable....................................................................................................
+
+    @Override
+    public void printTree(final IndentingPrinter printer) {
+        printer.print(this.value());
     }
 }

--- a/src/test/java/walkingkooka/net/UrlPathEmptyTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathEmptyTest.java
@@ -171,4 +171,14 @@ public final class UrlPathEmptyTest extends UrlPathTestCase<UrlPathEmpty> {
     Class<UrlPathEmpty> urlPathType() {
         return UrlPathEmpty.class;
     }
+
+    // TreePrintable....................................................................................................
+
+    @Test
+    public void testPrintTree() {
+        this.treePrintAndCheck(
+            UrlPathEmpty.EMPTY,
+            ""
+        );
+    }
 }

--- a/src/test/java/walkingkooka/net/UrlPathNotEmptyNormalizedTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNotEmptyNormalizedTest.java
@@ -223,4 +223,15 @@ public final class UrlPathNotEmptyNormalizedTest extends UrlPathTestCase<UrlPath
             "/path1/path2/%2A"
         );
     }
+
+    // TreePrintable....................................................................................................
+
+    @Test
+    public void testPrintTree() {
+        this.treePrintAndCheck(
+            UrlPath.parse("/path1/path2/../path22")
+                .normalize(),
+            "/path1/path22"
+        );
+    }
 }

--- a/src/test/java/walkingkooka/net/UrlPathNotEmptyUnnormalizedTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathNotEmptyUnnormalizedTest.java
@@ -210,4 +210,16 @@ public final class UrlPathNotEmptyUnnormalizedTest extends UrlPathTestCase<UrlPa
             "/path1/../path3/%2A"
         );
     }
+
+    // TreePrintable....................................................................................................
+
+    @Test
+    public void testPrintTree() {
+        final String path = "/path1/path2/../path22";
+
+        this.treePrintAndCheck(
+            UrlPath.parse(path),
+            path
+        );
+    }
 }

--- a/src/test/java/walkingkooka/net/UrlPathRootTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathRootTest.java
@@ -176,4 +176,14 @@ public final class UrlPathRootTest extends UrlPathTestCase<UrlPathRoot> {
     Class<UrlPathRoot> urlPathType() {
         return UrlPathRoot.class;
     }
+
+    // TreePrintable....................................................................................................
+
+    @Test
+    public void testPrintTree() {
+        this.treePrintAndCheck(
+            UrlPath.ROOT,
+            "/"
+        );
+    }
 }

--- a/src/test/java/walkingkooka/net/UrlPathTest.java
+++ b/src/test/java/walkingkooka/net/UrlPathTest.java
@@ -27,6 +27,7 @@ import walkingkooka.naming.PathTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.test.ParseStringTesting;
+import walkingkooka.text.printer.TreePrintableTesting;
 
 import java.util.Arrays;
 import java.util.List;
@@ -41,7 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public final class UrlPathTest implements ClassTesting2<UrlPath>,
     IteratorTesting,
     PathTesting<UrlPath, UrlPathName>,
-    ParseStringTesting<UrlPath> {
+    ParseStringTesting<UrlPath>,
+    TreePrintableTesting {
 
     // isStartsWithSeparator............................................................................................
 
@@ -1307,6 +1309,18 @@ public final class UrlPathTest implements ClassTesting2<UrlPath>,
     @Override
     public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
+    }
+
+    // TreePrintable ...................................................................................................
+
+    @Test
+    public void testTreePrint() {
+        final String path = "/api/1/hello";
+
+        this.treePrintAndCheck(
+            UrlPath.parse(path),
+            path
+        );
     }
 
     // ClassTestCase ...................................................................................................

--- a/src/test/java/walkingkooka/net/UrlPathTestCase.java
+++ b/src/test/java/walkingkooka/net/UrlPathTestCase.java
@@ -22,13 +22,16 @@ import walkingkooka.Cast;
 import walkingkooka.ToStringTesting;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.reflect.JavaVisibility;
+import walkingkooka.text.printer.TreePrintableTesting;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class UrlPathTestCase<P extends UrlPath> implements ClassTesting2<UrlPath>, ToStringTesting<UrlPath> {
+public abstract class UrlPathTestCase<P extends UrlPath> implements ClassTesting2<UrlPath>,
+    ToStringTesting<UrlPath>,
+    TreePrintableTesting {
 
     UrlPathTestCase() {
         super();


### PR DESCRIPTION
- Fixes HateosResourceMappingsRouter.toString() expands the UrlPath into components instead of using the string value.