### PR TITLE
HttpHandlerContext javadoc FIX

### DIFF
--- a/src/main/java/walkingkooka/net/http/server/HttpHandlerContext.java
+++ b/src/main/java/walkingkooka/net/http/server/HttpHandlerContext.java
@@ -20,7 +20,7 @@ package walkingkooka.net.http.server;
 import walkingkooka.Context;
 
 /**
- * The {@link Context} that accompanies each {@link HttpHandler#handle(HttpRequest, HttpResponse)}.
+ * The {@link Context} that accompanies each {@link HttpHandler#handle(HttpRequest, HttpResponse, HttpHandlerContext)}.
  */
 public interface HttpHandlerContext extends Context {
 }


### PR DESCRIPTION
- Missing javadoc update when adding HttpHandlerContext parameter to HttpHandler.